### PR TITLE
WIP: Create the RAT in 'chunks' for tiling so whole RAT and segment locations don't need to be in memory

### DIFF
--- a/bin/test_pyshepseg_tiling.py
+++ b/bin/test_pyshepseg_tiling.py
@@ -152,13 +152,14 @@ def main():
     # unfortunately to estimate the stats from the histogram 
     # we need the whole thing (well at least I don't *think* this
     # is possible to work it out from values accumulated from the chunks)
+    # TODO: check this
     attrTbl = band.GetDefaultRAT()
     histIdx = attrTbl.GetColOfUsage(gdal.GFU_PixelCount)
     hist = attrTbl.ReadAsArray(histIdx)
 
     utils.estimateStatsFromHisto(band, hist)
     
-    # Ideally, we'd be able to avoid this whole-of-RAT step by building
+    # TODO: Ideally, we'd be able to avoid this whole-of-RAT step by building
     # the colour table as part of calcHistogramTiled().
     utils.writeRandomColourTable(band, tiledSegResult.maxSegId+1)
     

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -71,6 +71,7 @@ TEMPFILES_EXT = 'kea'
 
 DFLT_TILESIZE = 4096
 DFLT_OVERLAPSIZE = 200
+# TODO: this should be a much bigger number (1million?)
 DFLT_CHUNKSIZE = 10000
 
 class TiledSegmentationResult(object):
@@ -918,8 +919,8 @@ def makeSegmentLocationsChunk(seg, segSize, minVal, maxVal):
         d[SegIdType(segid)] = obj
 
     (nRows, nCols) = seg.shape
-    for row in numpy.arange(nRows, dtype=numpy.uint32):
-        for col in numpy.arange(nCols, dtype=numpy.uint32):
+    for row in range(nRows):
+        for col in range(nCols):
             segid = seg[row, col]
             if (segid >= minVal and segid < maxVal and 
                         (minVal != 0 or segid != shepseg.SEGNULLVAL)):

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -847,6 +847,9 @@ def calcHistogramTiledChunk(segband, attrTbl, chunkMinVal, chunkMaxVal,
                 # TODO: work out what this returns, needs name, type (although
                 # this could be derived from the data) and usage.
                 # Is it and object? A tuple etc?
+                # TODO: the user function will likely want to have access to the 
+                # input image also. Should we provide the corresponding data for
+                # that image to it also?
                 result = ratBuilderFn(segLocations)
                 for colInfo in result:
                     # do we have this one yet?


### PR DESCRIPTION
This is really rough ATM....

The idea behind this PR is that the user should be able to build columns on the RAT with the tiling method. For huge rasters, the output of shepseg.makeSegmentLocations() will be prohibitively large. To circumvent this, the output image is read multiple times and each time a different range of segment ids ('chunks') are processed. In this case the size of the segment locations should be manageable. It is proposed that a user function can be provided and can return a list of columns to be written to the RAT for that chunk.

Currently this is tacked onto the histogram calculation (which seemed to make sense as it has to read this file for this anyway) and this has also been altered to work in chunks.

Check out the TODOs in the code to see where I am uncertain (most of it!).