### PR TITLE
Use Real type for histogram, plus check for existence first

### DIFF
--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -1364,8 +1364,12 @@ def calcHistogramTiled(segfile, maxSegId, writeToRat=True):
         numTableRows = int(maxSegId + 1)
         if attrTbl.GetRowCount() != numTableRows:
             attrTbl.SetRowCount(numTableRows)
-        attrTbl.CreateColumn('Histogram', gdal.GFT_Integer, gdal.GFU_PixelCount)
-        colNum = attrTbl.GetColumnCount() - 1
+            
+        colNum = attrTbl.GetColOfUsage(gdal.GFU_PixelCount)
+        if colNum == -1:
+            # Use GFT_Real to match rios.calcstats (And I think GDAL in general)
+            attrTbl.CreateColumn('Histogram', gdal.GFT_Real, gdal.GFU_PixelCount)
+            colNum = attrTbl.GetColumnCount() - 1
         attrTbl.WriteArray(hist, colNum)
 
     return hist

--- a/pyshepseg/utils.py
+++ b/pyshepseg/utils.py
@@ -105,8 +105,10 @@ def writeRandomColourTable(outBand, nRows):
     attrTbl.SetRowCount(nRows)
     
     for band in range(3):
-        attrTbl.CreateColumn(colNames[band], gdal.GFT_Integer, colUsages[band])
-        colNum = attrTbl.GetColumnCount() - 1
+        colNum = attrTbl.GetColOfUsage(colUsages[band])
+        if colNum == -1:
+            attrTbl.CreateColumn(colNames[band], gdal.GFT_Integer, colUsages[band])
+            colNum = attrTbl.GetColumnCount() - 1
         colour = numpy.random.random_integers(0, 255, size=nRows)
         attrTbl.WriteArray(colour, colNum)
         


### PR DESCRIPTION
This is to be more compatible with RIOS (and ERDAS Imagine, should that matter). Also means counts won't overflow. I think the behaviour before was a bit undefined if the Histogram column already existed..

Maybe we should also have a different type for the `hist` array?

@petescarth bit of a long shot but I wonder if this may have helped with your mangled file?