### PR TITLE
RatPage constructor was setting 'complete' flag for first segment in …

### DIFF
--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -1082,10 +1082,11 @@ class RatPage(object):
         self.intcols = numpy.empty((numIntCols, numSeg), dtype=numbaTypeForImageType)
         self.floatcols = numpy.empty((numFloatCols, numSeg), dtype=numpy.float32)
         self.complete = numpy.zeros(numSeg, dtype=types.boolean)
-        # The null segment is always complete
-        self.complete[0] = True
-        self.intcols[:, 0] = 0
-        self.floatcols[:, 0] = 0
+        if startSegId == shepseg.SEGNULLVAL:
+            # The null segment is always complete
+            self.complete[0] = True
+            self.intcols[:, 0] = 0
+            self.floatcols[:, 0] = 0
     
     def getIndexInPage(self, segId):
         """


### PR DESCRIPTION
…any page, not just the null segment. Harmless, but wrong. Now fixed, thanks to Sam's sharp eyes.

Tested on a decent-sized case, and all good. 