### PR TITLE
Catch any incomplete pages at end of stats processing and raise error

### DIFF
--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -837,14 +837,9 @@ def calcPerSegmentStatsTiled(imgfile, imgbandnum, segfile,
             
             writeCompletePages(pagedRat, attrTbl, statsSelection_fast)
 
-    # now mark all remaining pages as "complete" so they can be written 
-    # out. If not all segId's in the RAT have been found in the image
-    # then this step will write them out    
-    for pageId in pagedRat:
-        print('Not all segments for page {} found. Writing what we have.'.format(pageId))
-        ratPage = pagedRat[pageId]
-        ratPage.complete.fill(True)
-    writeCompletePages(pagedRat, attrTbl, statsSelection_fast)
+    # all pages should now be written. Raise an error if this not the case.
+    if len(pagedRat) > 0:
+        raise PyShepSegTilingError('Not all pixels found during processing')
 
 
 # This type is used for all numba jit-ed data which is supposed to 

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -218,24 +218,6 @@ def readSubsampledImageBand(bandObj, subsampleProp):
     imgSub = numpy.concatenate(tileRowList, axis=0)
     return imgSub
 
-
-def saveKMeansObj(kmeansObj, filename):
-    """
-    Saves the given KMeans object into the given filename. 
-    
-    Since the KMeans object is not pickle-able, use our own
-    simple JSON form to save the cluster centres. The 
-    corresponding function loadKMeansObj() can be used to
-    re-create the original object (at least functionally equivalent). 
-    """
-    # Check that it really is not pickle-able, I am just assuming....
-    
-
-def loadKMeansObj(filename):
-    """
-    Load a KMeans object from a file, as saved by saveKMeansObj(). 
-    """
-
 class TileInfo(object):
     """
     Class that holds the pixel coordinates of the tiles within 

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -87,7 +87,7 @@ class TiledSegmentationResult(object):
       maxSegId: Largest segment ID used in final segment image
       numTileRows: Number of rows of tiles used
       numTileCols: Number of columns of tiles used
-      subSamplePcnt: Percentage of image subsampled for clustering
+      subsamplePcnt: Percentage of image subsampled for clustering
       maxSpectralDiff: The value used to limit segment merging (in all tiles)
       kmeans: The sklearn KMeans object, after fitting
       
@@ -95,7 +95,7 @@ class TiledSegmentationResult(object):
     maxSegId = None
     numTileRows = None
     numTileCols = None
-    subSamplePcnt = None
+    subsamplePcnt = None
     maxSpectralDiff = None
     kmeans = None
 
@@ -291,7 +291,7 @@ def getTilesForFile(ds, tileSize, overlapSize):
 
 def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE, 
         overlapSize=DFLT_OVERLAPSIZE, minSegmentSize=50, numClusters=60, 
-        bandNumbers=None, subSamplePcnt=None, maxSpectralDiff='auto', 
+        bandNumbers=None, subsamplePcnt=None, maxSpectralDiff='auto', 
         imgNullVal=None, fixedKMeansInit=False, fourConnected=True, 
         verbose=False, simpleTileRecode=False, outputDriver='KEA',
         creationOptions=[], spectDistPcntile=50, kmeansObj=None):
@@ -304,7 +304,7 @@ def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE,
     The initial spectral clustering is performed on a sub-sample
     of the whole raster (using fitSpectralClustersWholeFile), 
     to create consistent clusters. These are then used as seeds 
-    for all individual tiles. Note that subSamplePcnt is used at 
+    for all individual tiles. Note that subsamplePcnt is used at 
     this stage, over the whole raster, and is not passed through to 
     shepseg.doShepherdSegmentation() for any further sub-sampling. 
     
@@ -336,11 +336,11 @@ def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE,
 
     t0 = time.time()
     if kmeansObj is None:
-        kmeansObj, subSamplePcnt, imgNullVal = fitSpectralClustersWholeFile(inDs, 
-            bandNumbers, numClusters, subSamplePcnt, imgNullVal, fixedKMeansInit)
+        kmeansObj, subsamplePcnt, imgNullVal = fitSpectralClustersWholeFile(inDs, 
+            bandNumbers, numClusters, subsamplePcnt, imgNullVal, fixedKMeansInit)
         if verbose:
             print("KMeans of whole raster {:.2f} seconds".format(time.time()-t0))
-            print("Subsample Percentage={:.2f}".format(subSamplePcnt))
+            print("Subsample Percentage={:.2f}".format(subsamplePcnt))
     
     # create a temp directory for use in splitting out tiles, overlaps etc
     tempDir = tempfile.mkdtemp()
@@ -414,7 +414,7 @@ def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE,
     tiledSegResult.maxSegId = maxSegId
     tiledSegResult.numTileRows = tileInfo.nrows
     tiledSegResult.numTileCols = tileInfo.ncols
-    tiledSegResult.subSamplePcnt = subSamplePcnt
+    tiledSegResult.subsamplePcnt = subsamplePcnt
     tiledSegResult.maxSpectralDiff = segResult.maxSpectralDiff
     tiledSegResult.kmeans = kmeansObj
     

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -854,6 +854,14 @@ def calcPerSegmentStatsTiled(imgfile, imgbandnum, segfile,
             
             writeCompletePages(pagedRat, attrTbl, statsSelection_fast)
 
+    # now mark all remaining pages as "complete" so they can be written 
+    # out. There will always be some segs at the end (or beginning) that
+    # don't have all the data but still need to be written out          
+    for pageId in pagedRat:
+        ratPage = pagedRat[pageId]
+        ratPage.complete.fill(True)
+    writeCompletePages(pagedRat, attrTbl, statsSelection_fast)
+
 
 # This type is used for all numba jit-ed data which is supposed to 
 # match the data type of the imagery pixels. Int64 should be enough

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -309,10 +309,10 @@ def getTilesForFile(ds, tileSize, overlapSize):
 
 def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE, 
         overlapSize=DFLT_OVERLAPSIZE, minSegmentSize=50, numClusters=60, 
-        bandNumbers=None, subsamplePcnt=None, maxSpectralDiff='auto', 
+        bandNumbers=None, subSamplePcnt=None, maxSpectralDiff='auto', 
         imgNullVal=None, fixedKMeansInit=False, fourConnected=True, 
         verbose=False, simpleTileRecode=False, outputDriver='KEA',
-        creationOptions=[], spectDistPcntile=50):
+        creationOptions=[], spectDistPcntile=50, kmeansObj=None):
     """
     Run the Shepherd segmentation algorithm in a memory-efficient
     manner, suitable for large raster files. Runs the segmentation
@@ -322,7 +322,7 @@ def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE,
     The initial spectral clustering is performed on a sub-sample
     of the whole raster (using fitSpectralClustersWholeFile), 
     to create consistent clusters. These are then used as seeds 
-    for all individual tiles. Note that subsamplePcnt is used at 
+    for all individual tiles. Note that subSamplePcnt is used at 
     this stage, over the whole raster, and is not passed through to 
     shepseg.doShepherdSegmentation() for any further sub-sampling. 
     
@@ -353,11 +353,12 @@ def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE,
         bandNumbers = range(1, inDs.RasterCount+1)
 
     t0 = time.time()
-    kmeansObj, subSamplePcnt, imgNullVal = fitSpectralClustersWholeFile(inDs, 
-            bandNumbers, numClusters, subsamplePcnt, imgNullVal, fixedKMeansInit)
-    if verbose:
-        print("KMeans of whole raster {:.2f} seconds".format(time.time()-t0))
-        print("Subsample Percentage={:.2f}".format(subSamplePcnt))
+    if kmeansObj is None:
+        kmeansObj, subSamplePcnt, imgNullVal = fitSpectralClustersWholeFile(inDs, 
+            bandNumbers, numClusters, subSamplePcnt, imgNullVal, fixedKMeansInit)
+        if verbose:
+            print("KMeans of whole raster {:.2f} seconds".format(time.time()-t0))
+            print("Subsample Percentage={:.2f}".format(subSamplePcnt))
     
     # create a temp directory for use in splitting out tiles, overlaps etc
     tempDir = tempfile.mkdtemp()

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -855,9 +855,10 @@ def calcPerSegmentStatsTiled(imgfile, imgbandnum, segfile,
             writeCompletePages(pagedRat, attrTbl, statsSelection_fast)
 
     # now mark all remaining pages as "complete" so they can be written 
-    # out. There will always be some segs at the end (or beginning) that
-    # don't have all the data but still need to be written out          
+    # out. If not all segId's in the RAT have been found in the image
+    # then this step will write them out    
     for pageId in pagedRat:
+        print('Not all segments for page {} found. Writing what we have.'.format(pageId))
         ratPage = pagedRat[pageId]
         ratPage.complete.fill(True)
     writeCompletePages(pagedRat, attrTbl, statsSelection_fast)

--- a/pyshepseg/utils.py
+++ b/pyshepseg/utils.py
@@ -114,8 +114,10 @@ def writeRandomColourTable(outBand, nRows):
         
     alpha = numpy.full((nRows,), 255, dtype=numpy.uint8)
     alpha[shepseg.SEGNULLVAL] = 0
-    attrTbl.CreateColumn('Alpha', gdal.GFT_Integer, gdal.GFU_Alpha)
-    colNum = attrTbl.GetColumnCount() - 1
+    colNum = attrTbl.GetColOfUsage(gdal.GFU_Alpha)
+    if colNum == -1:
+        attrTbl.CreateColumn('Alpha', gdal.GFT_Integer, gdal.GFU_Alpha)
+        colNum = attrTbl.GetColumnCount() - 1
     attrTbl.WriteArray(alpha, colNum)
 
 


### PR DESCRIPTION
In some situations the user may have a RAT that has more segments than what is in the image. For example, if they have taken a subset. In this case some pages will not be written back to the file as they are never marked as 'complete'. 

I think we should deal with these situations. The attached PR ensures all incomplete pages are written at the end and a warning printed. I'd also be happy with raising an error in instead. I don't think we should let this go through undetected though. 

This also fixes with a problem not detecting we already have an Alpha column when creating a colour table. 

BTW I'm working on a new and improved "compress" algorithm to properly subset imagery and the RAT. Stay tuned.

cc: @petescarth