### PR TITLE
Open the imgfile as read only to support vsis3

### DIFF
--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -796,7 +796,7 @@ def calcPerSegmentStatsTiled(imgfile, imgbandnum, segfile,
 
     imgds = imgfile
     if not isinstance(imgds, gdal.Dataset):
-        imgds = gdal.Open(imgfile, gdal.GA_Update)
+        imgds = gdal.Open(imgfile, gdal.GA_ReadOnly)
     imgband = imgds.GetRasterBand(imgbandnum)
     if (imgband.DataType == gdal.GDT_Float32 or 
             imgband.DataType == gdal.GDT_Float64):

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -147,7 +147,7 @@ def fitSpectralClustersWholeFile(inDs, bandNumbers, numClusters=60,
         subsampleProp = numpy.sqrt(subsamplePcnt / 100.0)
     
     if imgNullVal is None:
-        imgNullVal = getImgNullValue(inDs)
+        imgNullVal = getImgNullValue(inDs, bandNumbers)
     
     bandList = []
     for bandNum in bandNumbers:
@@ -162,7 +162,7 @@ def fitSpectralClustersWholeFile(inDs, bandNumbers, numClusters=60,
     
     return (kmeansObj, subsamplePcnt, imgNullVal)
     
-def getImgNullValue(inDs):
+def getImgNullValue(inDs, bandNumbers):
     """
     Return the null value for the given dataset. Raises an error if
     not all bands have the same null value. 
@@ -351,7 +351,7 @@ def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE,
             
     elif imgNullVal is None:
         # make sure we have the null value, even if they have supplied the kMeans
-        imgNullVal = getImgNullValue(inDs)
+        imgNullVal = getImgNullValue(inDs, bandNumbers)
     
     # create a temp directory for use in splitting out tiles, overlaps etc
     tempDir = tempfile.mkdtemp()

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -147,7 +147,7 @@ def fitSpectralClustersWholeFile(inDs, bandNumbers, numClusters=60,
         subsampleProp = numpy.sqrt(subsamplePcnt / 100.0)
     
     if imgNullVal is None:
-        imgNullVal = getImgNullValue(inDS)
+        imgNullVal = getImgNullValue(inDs)
     
     bandList = []
     for bandNum in bandNumbers:
@@ -351,7 +351,7 @@ def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE,
             
     elif imgNullVal is None:
         # make sure we have the null value, even if they have supplied the kMeans
-        imgNullVal = getImgNullValue(inDS)
+        imgNullVal = getImgNullValue(inDs)
     
     # create a temp directory for use in splitting out tiles, overlaps etc
     tempDir = tempfile.mkdtemp()


### PR DESCRIPTION
This pull request changes the calcPerSegmentStatsTiled function so that the imgfile is opened in readonly mode. 

Opening the file in update mode causes problems if the file is accessed in S3 storage.