### PR TITLE
Handle nodata in source image during stats calculation

### DIFF
--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -916,6 +916,13 @@ def accumulateSegDict(segDict, noDataDict, imgNullVal, tileSegments, tileImageDa
         for x in range(xsize):
             segId = tileSegments[y, x]
             if segId != shepseg.SEGNULLVAL:
+            
+                # always create a empty dictionary for this segId
+                # even if we haven't got any non-nodata pixels yet
+                # because we loop through values in segDict when calculating dtats
+                if segId not in segDict:
+                    segDict[segId] = Dict.empty(key_type=numbaTypeForImageType, 
+                        value_type=types.uint32)
                 
                 imgVal = tileImageData[y, x]
                 imgVal_typed = numbaTypeForImageType(imgVal)
@@ -928,9 +935,6 @@ def accumulateSegDict(segDict, noDataDict, imgNullVal, tileSegments, tileImageDa
 
                 else:
                     # else populate histogram (note: not done if all nodata for this segment)
-                    if segId not in segDict:
-                        segDict[segId] = Dict.empty(key_type=numbaTypeForImageType, 
-                            value_type=types.uint32)
                     d = segDict[segId]
                     if imgVal_typed not in d:
                         d[imgVal_typed] = types.uint32(0)
@@ -996,10 +1000,8 @@ def calcStatsForCompletedSegs(segDict, noDataDict, pagedRat, statsSelection_fast
             ratPage.setSegmentComplete(segId)
             
             # Stats now done for this segment, so remove its histogram
-            # (if there was one)
-            if segId in segDict:
-                segDict.pop(segId)
-            # same for nodata
+            segDict.pop(segId)
+            # same for nodata (if there is one)
             if segId in noDataDict:
                 noDataDict.pop(segId)
 

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -919,7 +919,7 @@ def accumulateSegDict(segDict, noDataDict, imgNullVal, tileSegments, tileImageDa
             
                 # always create a empty dictionary for this segId
                 # even if we haven't got any non-nodata pixels yet
-                # because we loop through values in segDict when calculating dtats
+                # because we loop through keys of segDict when calculating stats
                 if segId not in segDict:
                     segDict[segId] = Dict.empty(key_type=numbaTypeForImageType, 
                         value_type=types.uint32)
@@ -950,7 +950,7 @@ def checkSegComplete(segDict, noDataDict, segSize, segId):
     the segment size
     """
     count = 0
-    # add up the counts of the histogram (handle all being nodata)
+    # add up the counts of the histogram
     if segId in segDict:
         d = segDict[segId]
         for pixVal in d:

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -806,7 +806,8 @@ def calcPerSegmentStatsTiled(imgfile, imgbandnum, segfile,
     output RAT. 
     The statName is a string used to identify which statistic 
     is to be calculated. Available options are:
-        'min', 'max', 'mean', 'stddev', 'median', 'mode', 'percentile'.
+        'min', 'max', 'mean', 'stddev', 'median', 'mode', 
+        'percentile', 'pixcount'.
     The 'percentile' statistic requires the 3-element form, with 
     the 3rd element being the percentile to be calculated. 
     
@@ -825,6 +826,9 @@ def calcPerSegmentStatsTiled(imgfile, imgbandnum, segfile,
     that aren't the nodata value then the value passed in as
     missingStatsValue is put into the RAT for the requested
     statistics.
+    
+    The 'pixcount' statName can be used to find the number of
+    valid pixels (not nodata) that were used to calculate the statistics.
 
     """
     segds = segfile
@@ -1220,6 +1224,7 @@ STATID_STDDEV = 3
 STATID_MEDIAN = 4
 STATID_MODE = 5
 STATID_PERCENTILE = 6
+STATID_PIXCOUNT = 7
 statIDdict = {
     'min':STATID_MIN,
     'max':STATID_MAX,
@@ -1227,7 +1232,8 @@ statIDdict = {
     'stddev':STATID_STDDEV,
     'median':STATID_MEDIAN,
     'mode':STATID_MODE,
-    'percentile':STATID_PERCENTILE
+    'percentile':STATID_PERCENTILE,
+    'pixcount':STATID_PIXCOUNT
 }
 NOPARAM = -1
 
@@ -1413,6 +1419,8 @@ class SegmentStats(object):
             val = self.mode
         elif statID == STATID_PERCENTILE:
             val = self.getPercentile(param)
+        elif statID == STATID_PIXCOUNT:
+            val = self.pixCount
         return val
 
 


### PR DESCRIPTION
Fixes #19 

Ignores pixels that are equal to the nodata (if set). Really rough initial commit, will do more testing tomorrow. 

@neilflood any issues with this approach?