### PR TITLE
use numpy.distutils as distutils now deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@
 #CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
 #WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from distutils.core import setup
+from numpy.distutils.core import setup
 import pyshepseg
 
 setup(name='pyshepseg',


### PR DESCRIPTION
Moving to `numpy.distutils` seems preferable to `setuptools`. This is what we did for RIOS.