### PR TITLE
Make parts of doTiledShepherdSegmentation() separate

### DIFF
--- a/parallel_examples/README.md
+++ b/parallel_examples/README.md
@@ -1,0 +1,4 @@
+# Parallel Examples
+
+Under this directory are examples of running the tiled segmentation in
+parallel. 

--- a/parallel_examples/awsbatch/Dockerfile
+++ b/parallel_examples/awsbatch/Dockerfile
@@ -1,0 +1,77 @@
+FROM ubuntu:21.04
+
+# Needed in case tzdata gets upgraded
+ENV TZ=Australia/Brisbane
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Use EUmirrors
+RUN sed -i 's/http:\/\/archive./http:\/\/eu.archive./g' /etc/apt/sources.list
+
+# Update Ubuntu software stack and install base GDAL stack
+RUN apt-get update
+RUN apt-get upgrade -y
+RUN apt-get install -y python3-gdal python3-boto3 python3-setuptools python3-sklearn \
+		python3-numba wget g++ cmake libhdf5-dev libgdal-dev unzip
+RUN apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV SW_VOLUME=/ubarscsw
+RUN mkdir $SW_VOLUME
+
+ENV SERVICEUSER=ubarscuser
+RUN useradd --create-home --shell /bin/bash ${SERVICEUSER}
+
+ENV KEALIB_VERSION=1.4.14
+RUN cd /tmp \
+    && wget -q https://github.com/ubarsc/kealib/releases/download/kealib-${KEALIB_VERSION}/kealib-${KEALIB_VERSION}.tar.gz \
+    && tar xf kealib-${KEALIB_VERSION}.tar.gz \
+    && cd kealib-${KEALIB_VERSION} \
+    && mkdir build \
+    && cd build \
+    && cmake -D CMAKE_INSTALL_PREFIX=${SW_VOLUME} -D LIBKEA_WITH_GDAL=ON .. \
+    && make \
+    && make install \
+    && cd ../.. \
+    && rm -rf kealib-${KEALIB_VERSION} kealib-${KEALIB_VERSION}.tar.gz
+
+RUN cd /tmp \
+    && wget https://github.com/gillins/pyshepseg/archive/refs/heads/parallel_friendly.zip \
+    && unzip parallel_friendly.zip \
+    && cd pyshepseg-parallel_friendly \
+    && python3 setup.py install --prefix=${SW_VOLUME} \
+    && cd .. \
+    && rm -rf parallel_friendly.zip pyshepseg-parallel_friendly
+
+ENV PYTHONPATH=${SW_VOLUME}/lib/python3.9/site-packages
+ENV LD_LIBRARY_PATH=${SW_VOLUME}/lib
+ENV GDAL_DRIVER_PATH=${SW_VOLUME}/lib/gdalplugins
+
+ENV PYTHONUNBUFFERED=1
+
+ENV GDAL_PAM_ENABLED=NO
+ENV GDAL_CACHEMAX=1024000000
+ENV GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR
+ENV GDAL_HTTP_MERGE_CONSECUTIVE_RANGES=YES
+ENV GDAL_HTTP_MULTIPLEX=YES
+ENV CPL_VSIL_CURL_ALLOWED_EXTENSIONS=".tif,.TIF,.tiff,.vrt,.zip"
+ENV VSI_CACHE=True
+ENV VSI_CACHE_SIZE=1024000000
+ENV GDAL_HTTP_MAX_RETRY=10
+ENV GDAL_HTTP_MAX_RETRY=3
+ENV CPL_ZIP_ENCODING=UTF-8
+
+COPY do_prepare.py $SW_VOLUME/bin
+COPY do_tile.py $SW_VOLUME/bin
+COPY do_stitch.py $SW_VOLUME/bin
+
+USER $SERVICEUSER
+
+# a few quick tests
+#RUN gdal_translate --formats | grep KEA
+RUN python3 -c 'from osgeo import gdal;assert(gdal.GetDriverByName("KEA") is not None)'
+RUN python3 -c 'from pyshepseg import tiling'
+
+# export the volume
+VOLUME $SW_VOLUME
+
+# set the workdir to the home directory for our user (not sure if right thing to
+WORKDIR /home/${SERVICEUSER}

--- a/parallel_examples/awsbatch/README.md
+++ b/parallel_examples/awsbatch/README.md
@@ -1,0 +1,71 @@
+# AWS Batch
+
+The files in this folder contain a working demonstration of how
+to run the tiled segmentation in parallel on AWS Batch.
+
+## Contents
+
+### CloudFormation
+
+`template/template.yaml`
+
+Contains the CloudFormation template to create the AWS Batch environment
+
+`create-stack.sh`
+
+Invokes CloudFormation to create the AWS Batch environment from `template/template.yaml`
+to create a CloudFormation stack called `ubarsc-parallel-seg`.
+
+`delete-stack.sh` 
+
+Deletes the AWS Batch environment.
+
+`modify-stack.sh`
+
+Attempts to modify the AWS Batch environment by applying any changes to `template/template.yaml`.
+
+### Docker
+
+AWS Batch requires a Docker image to be pushed to AWS ECR.
+
+`Dockerfile`
+
+Contains instructions for creating a Docker Image with the required software
+to perform the tiled segmentation.
+
+`build_docker.sh`
+
+Builds the Docker Image from Dockerfile
+
+`push_to_ecr.sh`
+
+Pushes the Docker Image to a repository on AWS ECR called "ubarsc_parallel_seg". Note this 
+repository is NOT created by the CloudFormation script above.
+
+### Supporting Scripts
+
+These are copied into the Docker Image by the `Dockerfile`.
+
+`do_prepare.py`
+
+Runs `tiling.doTiledShepherdSegmentation_prepare()` and copies the resulting data to a pickle file
+to the specified S3 Bucket to be picked up by the following steps.
+
+This is the first time we know how many tiles there are so this script also kicks off
+the appropriate number of array jobs (each running `do_tile.py` - see below). It also submits a final
+job (dependent on all the `do_tile.py` jobs completing) that runs `do_stitch.py` (see below).
+
+`do_tile.py`
+
+Runs `tiling.doTiledShepherdSegmentation_doOne()`. It loads the required data from the saved pickle
+and outputs the processed tile and saves it to the specified S3 Bucket to be picked up by `do_stitch.py`.
+Which tile is being processed is specified by the `AWS_BATCH_JOB_ARRAY_INDEX` environment variable -
+refer to the AWS Batch documentation on array jobs for more information.
+
+`do_stitch.py`
+
+Runs `tiling.doTiledShepherdSegmentation_finalize()`. It loads the required data from the saved pickle
+and determines the names of the individual tiles that have been processed by `do_tile.py`. This
+generates the output (stitched) file and copies to S3. It also deletes all temporary files from S3.
+
+

--- a/parallel_examples/awsbatch/build_docker.sh
+++ b/parallel_examples/awsbatch/build_docker.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker build -f Dockerfile --tag ubarsc_parallel_seg .

--- a/parallel_examples/awsbatch/create-stack.sh
+++ b/parallel_examples/awsbatch/create-stack.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+aws cloudformation create-stack --stack-name ubarsc-parallel-seg \
+    --template-body file://template/template.yaml \
+    --capabilities CAPABILITY_NAMED_IAM --region eu-central-1

--- a/parallel_examples/awsbatch/delete-stack.sh
+++ b/parallel_examples/awsbatch/delete-stack.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+aws cloudformation delete-stack --stack-name ubarsc-parallel-seg --region eu-central-1
+echo 'Stack Deletion in progress... Wait a few minutes'

--- a/parallel_examples/awsbatch/do_finalize.py
+++ b/parallel_examples/awsbatch/do_finalize.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+
+import io
+import pickle
+import argparse
+import tempfile
+import shutil
+import boto3
+from pyshepseg import tiling
+
+def getCmdargs():
+    p.add_argument("--bucket", required=True,
+        help="S3 Bucket to use")
+    p.add_argument("--infile", required=True,
+        help="Path in --bucket to use as input file")
+    p.add_argument("--outfile", required=True,
+        help="Path in --bucket to use as output file (.kea)")
+    p.add_argument("--pickle", required=True,
+        help="name of pickle with the result of the preparation")
+    p.add_argument("--overlapsize", required=True, type=int,
+        help="Tile Overlap to use. (default=%(default)s)")
+
+    cmdargs = p.parse_args()
+
+    return cmdargs
+
+def main()
+    cmdargs = getCmdargs()
+
+    s3 = boto3.client('s3')
+    with io.BytesIO() as fileobj:
+        s3.download_fileobj(cmdargs.bucket, cmdargs.pickle, fileobj)
+        fileobj.seek(0)
+
+        dataFromPickle = pickle.load(fileobj)
+
+    inPath = '/vsis3/' + cmdargs.bucket + '/' + cmdargs.infile
+    inDs = gdal.Open(inPath)
+
+    tempDir = tempfile.mkdtemp()
+
+    # work out what the tiles would have been named
+    tileFilenames = {}
+    for col, row in dataFromPickle['colRowList']:
+        filename = '/vsis3/' + cmdargs.bucket + '/' + 'tile_{}_{}.{}'.format(col, row, 'tif')
+        tileFilenames[(col, row)] = filename    
+
+    localOutfile = os.path.join(tempDir, os.path.basename(cmdargs.outfile))
+
+    maxSegId, hasEmptySegments = tiling.doTiledShepherdSegmentation_finalize(
+            inDs, tempDir, tileFilenames, dataFromPickle['tileInfo'], 
+            cmdargs.overlapsize, tempDir)
+
+    s3.upload_file(localOutfile, cmdargs.bucket, cmdargs.outfile)
+
+    shutil.rmtree(tempDir)
+
+if __name__ == '__main__':
+    main()

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -12,6 +12,8 @@ def getCmdargs():
         help="S3 Bucket to use")
     p.add_argument("--infile", required=True,
         help="Path in --bucket to use as input file")
+    p.add_argument("--outfile", required=True,
+        help="Path in --bucket to use as output file (.kea)")
     p.add_argument("-b", "--bands", default="3,4,5", 
         help="Comma seperated list of bands to use. 1-based. (default=%(default)s)")
     p.add_argument("--tilesize", required=True, type=int,
@@ -72,20 +74,16 @@ def main():
     print('Tiles Job Id', tilesJobId)
 
     # now submit a dependent job with the stitching
-    """
     response = batch.submit_job(jobName="pyshepseg_stitch",
             jobQueue=cmdargs.jobqueue,
             jobDefinition=cmdargs.jobdefnstitch,
-
             dependsOn=[{'jobId': tilesJobId}],
             containerOverrides={
                 "command": ['/usr/bin/python3', '/ubarscsw/bin/do_stitch.py',
                     '--bucket', cmdargs.bucket, '--outfile', cmdargs.outfile,
                     '--infile', cmdargs.infile, '--pickle', cmdargs.pickle,
-                    '--tilesize', str(cmdargs.tilesize), 
                     '--overlapsize', str(cmdargs.overlapsize)]})
     print('Stitching Job Id', response['jobId'])
-    """
 
 if __name__ == '__main__':
     main()

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import io
+import pickle
+import argparse
+import boto3
+from pyshepseg import tiling
+
+def getCmdargs():
+    p = argparse.ArgumentParser()
+    p.add_argument("--bucket", required=True,
+        help="S3 Bucket to use")
+    p.add_argument("--infile", required=True,
+        help="Path in --bucket to use as input file")
+    p.add_argument("-b", "--bands", default="3,4,5", 
+        help="Comma seperated list of bands to use. 1-based. (default=%(default)s)")
+    p.add_argument("--tilesize", required=True, type=int,
+        help="Tile Size to use. (default=%(default)s)")
+    p.add_argument("--overlapsize", required=True, type=int,
+        help="Tile Overlap to use. (default=%(default)s)")
+    p.add_argument("--pickle", required=True,
+        help="name of pickle to save result of preparation into")
+    p.add_argument("--region", default="eu-central-1",
+        help="Region to run the jobs in. (default=%(default)s)")
+    p.add_argument("--jobqueue", default="PyShepSegBatchProcessingJobQueue",
+        help="Name of Job Queue to use. (default=%(default)s)")
+    p.add_argument("--jobdefntile", default="PyShepSegBatchJobDefinitionTile",
+        help="Name of Job Definition to use for tile jobs. (default=%(default)s)")
+    p.add_argument("--jobdefnstitch", default="PyShepSegBatchJobDefinitionStitch",
+        help="Name of Job Definition to use for the stitch job. (default=%(default)s)")
+
+    cmdargs = p.parse_args()
+    # turn string of bands into list of ints
+    cmdargs.bands = [int(x) for x in cmdargs.bands.split(',')]
+
+    return cmdargs
+
+def main():
+    cmdargs = getCmdargs()
+
+    batch = boto3.client('batch', region_name=cmdargs.region)
+    s3 = boto3.client('s3')
+
+    inPath = '/vsis3/' + cmdargs.bucket + '/' + cmdargs.infile
+
+    # run the initial part of the tiled segmentation
+    inDs, bandNumbers, kmeansObj, subsamplePcnt, imgNullVal, tileInfo = (
+        tiling.doTiledShepherdSegmentation_prepare(inPath, 
+        bandNumbers=cmdargs.bands, tileSize=cmdargs.tilesize, 
+        overlapSize=cmdargs.overlapsize))
+
+    # pickle the required input data that each of the tiles will need
+    colRowList = sorted(tileInfo.tiles.keys(), key=lambda x:(x[1], x[0]))
+    dataToPickle = {'tileInfo': tileInfo, 'colRowList': colRowList, 
+        'bandNumbers': bandNumbers, 'imgNullVal': imgNullVal, 
+        'kmeansObj': kmeansObj}
+    with io.BytesIO() as fileobj:
+        pickle.dump(dataToPickle, fileobj)
+        fileobj.seek(0)
+        s3.upload_fileobj(fileobj, cmdargs.bucket, cmdargs.pickle)
+
+    # now submit an array job with all the tiles
+    response = batch.submit_job(jobName="pyshepseg_tiles",
+            jobQueue=cmdargs.jobqueue,
+            jobDefinition=cmdargs.jobdefntile,
+            arrayProperties={'size': len(colRowList)},
+            containerOverrides={
+                "command": ['/usr/bin/python3', '/ubarscsw/bin/do_tile.py',
+                    '--bucket', cmdargs.bucket, '--pickle', cmdargs.pickle,
+                    '--infile', cmdargs.infile]})
+    tilesJobId = response['jobId']
+    print('Tiles Job Id', tilesJobId)
+
+    # now submit a dependent job with the stitching
+    """
+    response = batch.submit_job(jobName="pyshepseg_stitch",
+            jobQueue=cmdargs.jobqueue,
+            jobDefinition=cmdargs.jobdefnstitch,
+
+            dependsOn=[{'jobId': tilesJobId}],
+            containerOverrides={
+                "command": ['/usr/bin/python3', '/ubarscsw/bin/do_stitch.py',
+                    '--bucket', cmdargs.bucket, '--outfile', cmdargs.outfile,
+                    '--infile', cmdargs.infile, '--pickle', cmdargs.pickle,
+                    '--tilesize', str(cmdargs.tilesize), 
+                    '--overlapsize', str(cmdargs.overlapsize)]})
+    print('Stitching Job Id', response['jobId'])
+    """
+
+if __name__ == '__main__':
+    main()

--- a/parallel_examples/awsbatch/do_stitch.py
+++ b/parallel_examples/awsbatch/do_stitch.py
@@ -59,7 +59,8 @@ def main():
 
     objs = [{'Key': cmdargs.pickle}]
     for col, row in tileFilenames:
-        objs.append({'Key': tileFilenames[(col, row)]})
+        filename = 'tile_{}_{}.{}'.format(col, row, 'tif')
+        objs.append({'Key': filename})
 
     s3.delete_objects(Bucket=cmdargs.bucket, Delete={'Objects': objs})
 

--- a/parallel_examples/awsbatch/do_stitch.py
+++ b/parallel_examples/awsbatch/do_stitch.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+"""
+Script that stiches all the tiles together by calling
+tiling.doTiledShepherdSegmentation_finalize().
+
+Uplaods the resulting segmentation to S3.
+"""
 
 import io
 import os
@@ -12,6 +18,9 @@ from pyshepseg import tiling
 from osgeo import gdal
 
 def getCmdargs():
+    """
+    Process the command line arguments.
+    """
     p = argparse.ArgumentParser()
     p.add_argument("--bucket", required=True,
         help="S3 Bucket to use")
@@ -29,8 +38,12 @@ def getCmdargs():
     return cmdargs
 
 def main():
+    """
+    Main routine
+    """
     cmdargs = getCmdargs()
 
+    # download the pickled data and unpickle.
     s3 = boto3.client('s3')
     with io.BytesIO() as fileobj:
         s3.download_fileobj(cmdargs.bucket, cmdargs.pickle, fileobj)
@@ -38,25 +51,32 @@ def main():
 
         dataFromPickle = pickle.load(fileobj)
 
+    # work out GDAL path to input file and open it
     inPath = '/vsis3/' + cmdargs.bucket + '/' + cmdargs.infile
     inDs = gdal.Open(inPath)
 
     tempDir = tempfile.mkdtemp()
 
     # work out what the tiles would have been named
+    # Note: this needs to match do_tile.py.
     tileFilenames = {}
     for col, row in dataFromPickle['colRowList']:
         filename = '/vsis3/' + cmdargs.bucket + '/' + 'tile_{}_{}.{}'.format(col, row, 'tif')
         tileFilenames[(col, row)] = filename    
 
+    # save the KEA file to the local path first
     localOutfile = os.path.join(tempDir, os.path.basename(cmdargs.outfile))
 
+    # do the stitching. Note maxSegId and hasEmptySegments not used here
+    # but ideally they would be saved somewhere also.
     maxSegId, hasEmptySegments = tiling.doTiledShepherdSegmentation_finalize(
             inDs, localOutfile, tileFilenames, dataFromPickle['tileInfo'], 
             cmdargs.overlapsize, tempDir)
 
+    # upload the KEA file
     s3.upload_file(localOutfile, cmdargs.bucket, cmdargs.outfile)
 
+    # cleanup temp files from S3
     objs = [{'Key': cmdargs.pickle}]
     for col, row in tileFilenames:
         filename = 'tile_{}_{}.{}'.format(col, row, 'tif')
@@ -64,6 +84,7 @@ def main():
 
     s3.delete_objects(Bucket=cmdargs.bucket, Delete={'Objects': objs})
 
+    # cleanup
     shutil.rmtree(tempDir)
 
 if __name__ == '__main__':

--- a/parallel_examples/awsbatch/do_stitch.py
+++ b/parallel_examples/awsbatch/do_stitch.py
@@ -52,16 +52,16 @@ def main():
     localOutfile = os.path.join(tempDir, os.path.basename(cmdargs.outfile))
 
     maxSegId, hasEmptySegments = tiling.doTiledShepherdSegmentation_finalize(
-            inDs, tempDir, tileFilenames, dataFromPickle['tileInfo'], 
+            inDs, localOutfile, tileFilenames, dataFromPickle['tileInfo'], 
             cmdargs.overlapsize, tempDir)
 
     s3.upload_file(localOutfile, cmdargs.bucket, cmdargs.outfile)
 
     objs = [{'Key': cmdargs.pickle}]
     for col, row in tileFilenames:
-        obj.append({'Key': tileFilenames[(col, row)]})
+        objs.append({'Key': tileFilenames[(col, row)]})
 
-    s3.delete_objects(cmdargs.bucket, {'Objects': objs})
+    s3.delete_objects(Bucket=cmdargs.bucket, Delete={'Objects': objs})
 
     shutil.rmtree(tempDir)
 

--- a/parallel_examples/awsbatch/do_stitch.py
+++ b/parallel_examples/awsbatch/do_stitch.py
@@ -2,14 +2,17 @@
 
 
 import io
+import os
 import pickle
 import argparse
 import tempfile
 import shutil
 import boto3
 from pyshepseg import tiling
+from osgeo import gdal
 
 def getCmdargs():
+    p = argparse.ArgumentParser()
     p.add_argument("--bucket", required=True,
         help="S3 Bucket to use")
     p.add_argument("--infile", required=True,
@@ -25,7 +28,7 @@ def getCmdargs():
 
     return cmdargs
 
-def main()
+def main():
     cmdargs = getCmdargs()
 
     s3 = boto3.client('s3')
@@ -53,6 +56,12 @@ def main()
             cmdargs.overlapsize, tempDir)
 
     s3.upload_file(localOutfile, cmdargs.bucket, cmdargs.outfile)
+
+    objs = [{'Key': cmdargs.pickle}]
+    for col, row in tileFilenames:
+        obj.append({'Key': tileFilenames[(col, row)]})
+
+    s3.delete_objects(cmdargs.bucket, {'Objects': objs})
 
     shutil.rmtree(tempDir)
 

--- a/parallel_examples/awsbatch/do_tile.py
+++ b/parallel_examples/awsbatch/do_tile.py
@@ -54,7 +54,9 @@ def main():
     segResult = tiling.doTiledShepherdSegmentation_doOne(inDs, filename,
             dataFromPickle['tileInfo'], col, row, dataFromPickle['bandNumbers'],
             dataFromPickle['imgNullVal'], dataFromPickle['kmeansObj'], 
-            tempfilesDriver='COG', tempfilesCreationOptions=['COMPRESS=DEFLATE'])
+            tempfilesDriver='GTiff', tempfilesCreationOptions=['COMPRESS=DEFLATE',
+                'ZLEVEL=1', 'PREDICTOR=2', 'TILED=YES', 'INTERLEAVE=BAND', 
+                'BIGTIFF=NO', 'BLOCKXSIZE=512', 'BLOCKYSIZE=512'])
 
     s3.upload_file(filename, cmdargs.bucket, os.path.basename(filename))
 

--- a/parallel_examples/awsbatch/do_tile.py
+++ b/parallel_examples/awsbatch/do_tile.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+import io
+import os
+import pickle
+import argparse
+import tempfile
+import shutil
+import boto3
+from pyshepseg import tiling
+
+from osgeo import gdal
+
+# set by AWS Batch
+ARRAY_INDEX = os.getenv('AWS_BATCH_JOB_ARRAY_INDEX')
+if ARRAY_INDEX is None:
+    raise SystemExit('Must set AWS_BATCH_JOB_ARRAY_INDEX env var')
+
+ARRAY_INDEX = int(ARRAY_INDEX)
+
+def getCmdargs():
+    p = argparse.ArgumentParser()
+    p.add_argument("--bucket", required=True,
+        help="S3 Bucket to use")
+    p.add_argument("--infile", required=True,
+        help="Path in --bucket to use as input file")
+    p.add_argument("--pickle", required=True,
+        help="name of pickle with the result of the preparation")
+
+    cmdargs = p.parse_args()
+
+    return cmdargs
+
+def main():
+    cmdargs = getCmdargs()
+
+    s3 = boto3.client('s3')
+    with io.BytesIO() as fileobj:
+        s3.download_fileobj(cmdargs.bucket, cmdargs.pickle, fileobj)
+        fileobj.seek(0)
+
+        dataFromPickle = pickle.load(fileobj)
+
+    inPath = '/vsis3/' + cmdargs.bucket + '/' + cmdargs.infile
+    inDs = gdal.Open(inPath)
+
+    tempDir = tempfile.mkdtemp()
+
+    col, row = dataFromPickle['colRowList'][ARRAY_INDEX]
+
+    filename = 'tile_{}_{}.{}'.format(col, row, 'tif')
+    filename = os.path.join(tempDir, filename)
+
+    segResult = tiling.doTiledShepherdSegmentation_doOne(inDs, filename,
+            dataFromPickle['tileInfo'], col, row, dataFromPickle['bandNumbers'],
+            dataFromPickle['imgNullVal'], dataFromPickle['kmeansObj'], 
+            tempfilesDriver='COG', tempfilesCreationOptions=['COMPRESS=DEFLATE'])
+
+    s3.upload_file(filename, cmdargs.bucket, os.path.basename(filename))
+
+    shutil.rmtree(tempDir)
+    
+if __name__ == '__main__':
+    main()

--- a/parallel_examples/awsbatch/modify-stack.sh
+++ b/parallel_examples/awsbatch/modify-stack.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+aws cloudformation update-stack --stack-name ubarsc-parallel-seg \
+    --template-body file://template/template.yaml \
+    --capabilities CAPABILITY_NAMED_IAM --region eu-central-1

--- a/parallel_examples/awsbatch/push_to_ecr.sh
+++ b/parallel_examples/awsbatch/push_to_ecr.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+DOCKER_TAG=ubarsc_parallel_seg
+ACCOUNT_ID=`aws sts get-caller-identity --query "Account" --output text`
+
+# ECR
+ECR_URL=${ACCOUNT_ID}.dkr.ecr.eu-central-1.amazonaws.com
+
+aws ecr get-login-password --region eu-central-1 | docker login --username AWS --password-stdin ${ECR_URL}
+
+docker tag ${DOCKER_TAG} ${ECR_URL}/${DOCKER_TAG}:latest
+
+docker push ${ECR_URL}/${DOCKER_TAG}:latest

--- a/parallel_examples/awsbatch/submit-job.py
+++ b/parallel_examples/awsbatch/submit-job.py
@@ -56,7 +56,7 @@ def main():
             containerOverrides={
                 "command": ['/usr/bin/python3', '/ubarscsw/bin/do_prepare.py',
                     '--bucket', cmdargs.bucket, '--pickle', PICKLE_NAME,
-                    '--infile', cmdargs.infile, 
+                    '--infile', cmdargs.infile, '--outfile', cmdargs.outfile,
                     '--bands', cmdargs.bands, '--tilesize', str(cmdargs.tilesize), 
                     '--overlapsize', str(cmdargs.overlapsize),
                     '--jobqueue', cmdargs.jobqueue, 

--- a/parallel_examples/awsbatch/submit-job.py
+++ b/parallel_examples/awsbatch/submit-job.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""
+Script that starts a tiled segmentation using AWS Batch.
+
+It runs the _prepare() function then submits an array jobs to run
+the _doOne() function on each time. Finally, it submits a 
+job to run the _finalize() function when the array jobs have 
+completed.
+"""
+
+import argparse
+import boto3
+
+# name of pickle to save to S3 with the info needed for each tile
+PICKLE_NAME = 'pyshepseg_tiling.pkl'
+
+def getCmdargs():
+    p = argparse.ArgumentParser()
+    p.add_argument("--bucket", required=True,
+        help="S3 Bucket to use")
+    p.add_argument("--infile", required=True,
+        help="Path in --bucket to use as input file")
+    p.add_argument("--outfile", required=True,
+        help="Path in --bucket to use as output file (.kea)")
+    p.add_argument("-b", "--bands", default="3,4,5", 
+        help="Comma seperated list of bands to use. 1-based. (default=%(default)s)")
+    p.add_argument("--jobqueue", default="PyShepSegBatchProcessingJobQueue",
+        help="Name of Job Queue to use. (default=%(default)s)")
+    p.add_argument("--jobdefnprepare", default="PyShepSegBatchJobDefinitionTile",
+        help="Name of Job Definition to use for the preparation job. (default=%(default)s)")
+    p.add_argument("--jobdefntile", default="PyShepSegBatchJobDefinitionTile",
+        help="Name of Job Definition to use for tile jobs. (default=%(default)s)")
+    p.add_argument("--jobdefnstitch", default="PyShepSegBatchJobDefinitionStitch",
+        help="Name of Job Definition to use for the stitch job. (default=%(default)s)")
+    p.add_argument("--region", default="eu-central-1",
+        help="Region to run the jobs in. (default=%(default)s)")
+    p.add_argument("--tilesize", default=4096, type=int,
+        help="Tile Size to use. (default=%(default)s)")
+    p.add_argument("--overlapsize", default=1024, type=int,
+        help="Tile Overlap to use. (default=%(default)s)")
+
+    cmdargs = p.parse_args()
+
+    return cmdargs
+
+def main():
+    cmdargs = getCmdargs()
+    
+    batch = boto3.client('batch', region_name=cmdargs.region)
+
+    # submit the prepare job
+    response = batch.submit_job(jobName="pyshepseg_prepare",
+            jobQueue=cmdargs.jobqueue,
+            jobDefinition=cmdargs.jobdefntile,
+            containerOverrides={
+                "command": ['/usr/bin/python3', '/ubarscsw/bin/do_prepare.py',
+                    '--bucket', cmdargs.bucket, '--pickle', PICKLE_NAME,
+                    '--infile', cmdargs.infile, 
+                    '--bands', cmdargs.bands, '--tilesize', str(cmdargs.tilesize), 
+                    '--overlapsize', str(cmdargs.overlapsize),
+                    '--jobqueue', cmdargs.jobqueue, 
+                    '--jobdefntile', cmdargs.jobdefntile,
+                    '--jobdefnstitch', cmdargs.jobdefnstitch]})
+    prepareId = response['jobId']
+    print('Prepare Job Id', prepareId)
+    
+
+if __name__ == '__main__':
+    main()

--- a/parallel_examples/awsbatch/template/template.yaml
+++ b/parallel_examples/awsbatch/template/template.yaml
@@ -1,0 +1,159 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'UBARSC AWS Batch Tiled Segmentation using CloudFormation'
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: VPC
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId:
+        Ref: VPC
+      InternetGatewayId:
+        Ref: InternetGateway
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: EC2 Security Group for instances launched in the VPC by Batch
+      VpcId:
+        Ref: VPC
+  Subnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.0.0.0/24
+      VpcId:
+        Ref: VPC
+      MapPublicIpOnLaunch: 'True'
+  Route:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId:
+        Ref: RouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId:
+        Ref: InternetGateway
+  SubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId:
+        Ref: RouteTable
+      SubnetId:
+        Ref: Subnet
+  BatchServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: batch.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
+  IamInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+      - Ref: EcsInstanceRole
+  EcsInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2008-10-17'
+        Statement:
+        - Sid: ''
+          Effect: Allow
+          Principal:
+            Service: ec2.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+      - arn:aws:iam::aws:policy/AmazonS3FullAccess
+      - arn:aws:iam::aws:policy/service-role/AWSBatchServiceEventTargetRole
+  # Job for doing individual tiles
+  BatchProcessingJobDefinitionTile:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      JobDefinitionName: PyShepSegBatchJobDefinitionTile
+      ContainerProperties:
+        Image:
+          Fn::Join:
+          - ''
+          - - Ref: AWS::AccountId
+            - .dkr.ecr.
+            - Ref: AWS::Region
+            - ".amazonaws.com/ubarsc_parallel_seg:latest"
+        Vcpus: 1
+        Memory: 4000
+      RetryStrategy:
+        Attempts: 1
+  # Job for stitching tiles together 
+  BatchProcessingJobDefinitionStitch:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      JobDefinitionName: PyShepSegBatchJobDefinitionStitch
+      ContainerProperties:
+        Image:
+          Fn::Join:
+          - ''
+          - - Ref: AWS::AccountId
+            - .dkr.ecr.
+            - Ref: AWS::Region
+            - ".amazonaws.com/ubarsc_parallel_seg:latest"
+        Vcpus: 1
+        Memory: 8000
+      RetryStrategy:
+        Attempts: 1
+  BatchProcessingJobQueue:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      JobQueueName: PyShepSegBatchProcessingJobQueue
+      Priority: 1
+      ComputeEnvironmentOrder:
+      - Order: 1
+        ComputeEnvironment:
+          Ref: ComputeEnvironment
+  ComputeEnvironment:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      Type: MANAGED
+      ComputeResources:
+        Type: EC2
+        MinvCpus: 0
+        DesiredvCpus: 0
+        MaxvCpus: 32
+        InstanceTypes:
+        #- a1.medium
+        - optimal
+        Subnets:
+        - Ref: Subnet
+        SecurityGroupIds:
+        - Ref: SecurityGroup
+        InstanceRole:
+          Ref: IamInstanceProfile
+      ServiceRole:
+        Ref: BatchServiceRole
+       
+Outputs:
+  ComputeEnvironmentArn:
+    Value:
+      Ref: ComputeEnvironment
+  BatchProcessingJobQueueArn:
+    Value:
+      Ref: BatchProcessingJobQueue
+  BatchProcessingJobDefinitionArn:
+    Value:
+      Ref: BatchProcessingJobDefinitionTile
+      Ref: BatchProcessingJobDefinitionStitch

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -345,7 +345,7 @@ def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE,
     """
  
     inDs, bandNumbers, kmeansObj, subsamplePcnt, imgNullVal, tileInfo = (
-        doTiledShepherdSegmentation_prepare(infile, outfile, tileSize, 
+        doTiledShepherdSegmentation_prepare(infile, tileSize, 
         overlapSize, bandNumbers, imgNullVal, kmeansObj, verbose, numClusters, 
         subsamplePcnt, fixedKMeansInit))
         
@@ -389,7 +389,7 @@ def doTiledShepherdSegmentation(infile, outfile, tileSize=DFLT_TILESIZE,
     
     return tiledSegResult
     
-def doTiledShepherdSegmentation_prepare(infile, outfile, tileSize=DFLT_TILESIZE, 
+def doTiledShepherdSegmentation_prepare(infile, tileSize=DFLT_TILESIZE, 
         overlapSize=DFLT_OVERLAPSIZE, bandNumbers=None, imgNullVal=None, 
         kmeansObj=None, verbose=False, numClusters=60, subsamplePcnt=None, 
         fixedKMeansInit=False):


### PR DESCRIPTION
....so they can potentially be called in parallel.

As promised @neilflood here is a very rough PR. Let me know what you think before I tidy up.

The idea is that a users script would run `doTiledShepherdSegmentation_prepare()` before submitting a script to call `doTiledShepherdSegmentation_doOne()` for each tile into a batch queue or whatever. The actual mechanism for passing `tileInfo` and the other parameters to each script is left to the user. When all these jobs have finished another script should be run to call `doTiledShepherdSegmentation_finalize()`. 

This is quite a minor change compared to what could be done but my idea was to leave it to others to flesh out something for their particular use case and batch queuing system.