### PR TITLE
ensure int and float cols get treated separately

### DIFF
--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -1284,15 +1284,20 @@ class RatPage(object):
         ndxInPage = self.getIndexInPage(segId)
         self.floatcols[colArrayNdx, ndxInPage] = val
             
-    def getRatVal(self, segId, colType, colArrayNdx):
+    def getRatValInt(self, segId, colArrayNdx):
         """
-        Get the RAT entry for the given segment.
+        Get the RAT entry for the given segment. For Ints.
         """
         ndxInPage = self.getIndexInPage(segId)
-        if colType == STAT_DTYPE_INT:
-            val = self.intcols[colArrayNdx, ndxInPage]
-        elif colType == STAT_DTYPE_FLOAT:
-            val = self.floatcols[colArrayNdx, ndxInPage]
+        val = self.intcols[colArrayNdx, ndxInPage]
+        return val
+
+    def getRatValFloat(self, segId, colArrayNdx):
+        """
+        Get the RAT entry for the given segment. For Floats.
+        """
+        ndxInPage = self.getIndexInPage(segId)
+        val = self.floatcols[colArrayNdx, ndxInPage]
         return val
     
     def setSegmentComplete(self, segId):

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -1860,6 +1860,7 @@ def readColDataIntoPageInt(page, data, idx, colType, minVal):
     for i in range(data.shape[0]):
         page.setRatValInt(i + minVal, idx, data[i])
 
+
 @njit
 def readColDataIntoPageFloat(page, data, idx, colType, minVal):
     """

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -1520,8 +1520,8 @@ class SegmentStats(object):
             val = self.min
         elif statID == STATID_MAX:
             val = self.max
-        elif statID == STATID_MEAN:
-            val = self.mean
+        elif statID == STATID_MEDIAN:
+            val = self.median
         elif statID == STATID_MODE:
             val = self.mode
         elif statID == STATID_PERCENTILE:
@@ -1538,8 +1538,8 @@ class SegmentStats(object):
         val = 0.0
         if statID == STATID_STDDEV:
             val = self.stddev
-        elif statID == STATID_MEDIAN:
-            val = self.median
+        elif statID == STATID_MEAN:
+            val = self.mean
         return val
 
 


### PR DESCRIPTION
as it appears the return type from `getStatsVal()` is always float due to the mix of types in that class. 

Note: there could be an argument for having the `counts` and `pixCount` also being handled differently as they are `uint32` rather than `int32`. But because they are written to (currently) `int32` columns maybe we should store them as `int32` to reduce the confusion...