### PR TITLE
Testing Sphinx with numpydoc

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+python:
+  version: "3.7"
+  install:
+    - requirements: doc/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,10 +5,6 @@
 # Required
 version: 2
 
-# Build documentation in the doc/ directory with Sphinx
-sphinx:
-   configuration: doc/source/conf.py
-
 python:
   version: "3.7"
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,7 @@
 version: 2
 
 python:
-  version: "3.7"
   install:
     - requirements: doc/requirements.txt
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,5 +8,3 @@ version: 2
 python:
   install:
     - requirements: doc/requirements.txt
-    - method: pip
-      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,10 @@
 # Required
 version: 2
 
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+   configuration: doc/conf.py
+
 python:
   version: "3.7"
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Build documentation in the doc/ directory with Sphinx
 sphinx:
-   configuration: doc/conf.py
+   configuration: doc/source/conf.py
 
 python:
   version: "3.7"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,1 @@
+numpydoc

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
 numpydoc
+numba

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,10 +12,8 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('..'))
 sys.path.insert(0, os.path.abspath('../..'))
-print('Running readthedocs from', os.curdir)
+print('Running readthedocs from', os.getcwd())
 
 
 # -- Project information -----------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,11 +29,10 @@ author = 'Neil Flood & Sam Gillingham'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'numpydoc'
+    'sphinx.ext.napoleon'
 ]
 napoleon_google_docstring = True
-napoleon_numpy_docstring = False
+napoleon_numpy_docstring = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,6 +31,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'numpydoc'
 ]
+numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -32,8 +32,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'numpydoc'
 ]
-napoleon_google_docstring = True
-napoleon_numpy_docstring = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,9 +10,12 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../..'))
+print('Running readthedocs from', os.curdir)
 
 
 # -- Project information -----------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,10 +29,10 @@ author = 'Neil Flood & Sam Gillingham'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon'
+    'numpydoc'
 ]
 napoleon_google_docstring = True
-napoleon_numpy_docstring = True
+napoleon_numpy_docstring = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,7 +13,6 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
-print('Running readthedocs from', os.getcwd())
 
 
 # -- Project information -----------------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,8 @@ author = 'Neil Flood & Sam Gillingham'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'numpydoc'
 ]
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -125,7 +125,7 @@ arbitrary percentile values, amongst others. The selected per-segment
 statistics are written to the segment image file as columns of a raster
 attribute table (RAT). 
 
-For details, see the help on the ``tiling.calcPerSegmentStatsTiled()`` 
+For details, see the help on the ``tilingstats.calcPerSegmentStatsTiled()``
 function. 
 
 Segment Colour Tables

--- a/pyshepseg/shepseg.py
+++ b/pyshepseg/shepseg.py
@@ -155,7 +155,7 @@ def doShepherdSegmentation(img, numClusters=60, clusterSubsamplePcnt=1,
         an image with a larger range of spectral distances. 
       spectDictPcntile : int
         See maxSpectralDiff
-      fourConnected : boolean
+      fourConnected : bool
         If True, use 4-way connectedness when clumping, otherwise use
         8-way
       imgNullVal : int or None
@@ -164,7 +164,7 @@ def doShepherdSegmentation(img, numClusters=60, clusterSubsamplePcnt=1,
         in the image array, it is important to give this null value, as it can
         stringly affect the initial spectral clustering, which in turn 
         strongly affects the final segmenation.
-      fixedKMeansInit : boolean
+      fixedKMeansInit : bool
         If fixedKMeansInit is True, then choose a fixed set of 
         cluster centres to initialize the KMeans algorithm. This can
         be useful to provide strict determinacy of the results by
@@ -267,7 +267,7 @@ def fitSpectralClusters(img, numClusters, subsamplePcnt, imgNullVal,
       imgNullVal : int or None
         If imgNullVal is not None, then pixels in img with this value in 
         any band are set to segNullVal in the output. 
-      fixedKMeansInit : boolean
+      fixedKMeansInit : bool
         If True, then use a simple algorithm to determine the fixed
         set of initial cluster centres. Otherwise allow the sklearn 
         routine to choose its own initial guesses. 
@@ -372,14 +372,14 @@ def diagonalClusterCentres(xSample, numClusters):
 
     Parameters
     ----------
-      xSample : ndarray (numPoints, numBands)
+      xSample : int ndarray (numPoints, numBands)
         A sample of data to be used for fitting
       numClusters : int
         Number of cluster centres to be calculated
     
     Returns
     -------
-      centres : ndarray (numPoints, numBands)
+      centres : int ndarray (numPoints, numBands)
         Initial cluster centres in spectral space
     
     """
@@ -436,19 +436,19 @@ def clump(img, ignoreVal, fourConnected=True, clumpId=1):
 
     Parameters
     ----------
-      img : int ndarray
-        2d array containing the data to be clumped.
+      img : int ndarray (nRows, nCols)
+        Image array containing the data to be clumped.
       ignoreVal : int
-        should be the no data value for the input
-      fourConnected : boolean
+        should be the "no data" value for the input
+      fourConnected : bool
         If True, use 4-way connected, otherwise 8-way
       clumpId : int
         The start clump id to use
 
     Returns
     -------
-      clumpimg : 2d uint32 array
-        2d uint32 array containing the clump ids
+      clumpimg : SegIdType ndarray (nRows, nCols)
+        Image array containing the clump IDs for each pixel
       clumpId : int
         The highest clumpid used + 1
     
@@ -570,7 +570,7 @@ def eliminateSinglePixels(img, seg, segSize, minSegId, maxSegId, fourConnected):
         Smallest segment ID
       maxSegId : SegIdType
         Largest segment ID
-      fourConnected : boolean
+      fourConnected : bool
         If True use 4-way connectedness, otherwise 8-way
 
     Notes

--- a/pyshepseg/shepseg.py
+++ b/pyshepseg/shepseg.py
@@ -887,7 +887,7 @@ def makeSegmentLocations(seg, segSize):
 
     Returns
     -------
-      segLoc : numba Dict
+      segLoc : numba.typed.Dict
         Indexed by segment ID number, each entry is a RowColArray
         object, giving the pixel coordinates of all pixels for that
         segment
@@ -1010,7 +1010,7 @@ def findMergeSegment(segId, segLoc, seg, segSize, spectSum, maxSpectralDiff,
     ----------
       segId : SegIdType
         Segment ID number of segment to merge
-      segLoc : numba Dict
+      segLoc : numba.typed.Dict
         Dictionary of per-segment pixel coordinates. As computed by
         makeSegmentLocations()
       seg : SegIdType ndarray (nRows, nCols)
@@ -1077,7 +1077,7 @@ def doMerge(segId, nbrSegId, seg, segSize, segLoc, spectSum):
       segSize : int ndarray (numSegments+1, )
         Counts of pixels in each segment, indexed by segment ID. Modified
         in place with new counts for both segments
-      segLoc : numba Dict
+      segLoc : numba.typed.Dict
         Dictionary of per-segment pixel coordinates. As computed by
         makeSegmentLocations()
       spectSum : float32 ndarray (numSegments+1, nBands)

--- a/pyshepseg/shepseg.py
+++ b/pyshepseg/shepseg.py
@@ -409,6 +409,25 @@ def autoMaxSpectralDiff(km, maxSpectralDiff, distPcntile):
 
     Otherwise, return the given current value.
 
+    Parameters
+    ----------
+      km : sklearn.cluster.KMeans 
+        KMeans clustering object
+      maxSpectralDiff : str or float
+        It is given in the units of the spectral space of img. If 
+        maxSpectralDiff is 'auto', a default value will be calculated
+        from the spectral distances between cluster centres, as a 
+        percentile of the distribution of these (distPcntile). 
+        The value of distPcntile should be lowered when segementing 
+        an image with a larger range of spectral distances. 
+      distPcntile : int
+        See maxSpectralDiff
+
+    Returns
+    -------
+      maxSpectralDiff : int
+        The value to use as maxSpectralDiff.
+
     """
     # Calculate distances between pairs of cluster centres
     centres = km.cluster_centers_
@@ -604,6 +623,26 @@ def mergeSinglePixels(img, seg, segSize, segToElim, fourConnected):
     segSize arrays in place, and returns the number of segments 
     eliminated. 
     
+    Parameters
+    ----------
+      img : int ndarray
+        (nBands, nRows, nCols)
+        the original spectral image
+      seg : int ndarray (nRows, nCols)
+        the image of segments
+      segSize : int array (numSeg+1, )
+        Array of pixel counts for every segment
+      segToElim : int ndarray
+        (3, maxSegId)
+        Temporary storage for segments to be eliminated
+      fourConnected : bool
+        If True use 4-way connectedness, otherwise 8-way
+        
+    Returns
+    -------
+      numEliminated : int
+        Number of segments eliminated
+
     """
     (nRows, nCols) = seg.shape
     numEliminated = 0

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -19,8 +19,8 @@ to allow sufficient initial segments to characterize the variation.
 
 Related to this, one may also consider reducing the percentile
 used for automatic estimation of maxSpectralDiff (see 
-:func:`shepseg.doShepherdSegmentation` and :func:`shepseg.autoMaxSpectralDiff`
-for further details). 
+:func:`pyshepseg.shepseg.doShepherdSegmentation` and
+:func:`pyshepseg.shepseg.autoMaxSpectralDiff` for further details).
 
 Because of these caveats, one should be very cautious about 
 segmenting something like a continental-scale image. There is a 
@@ -1551,6 +1551,14 @@ def writeCompletedPagesForSubset(inRAT, outRAT, outPagedRat):
     """
     For the subset operation. Writes out any completed pages to outRAT
     using the inRAT as a template.
+
+    Parameters
+    ----------
+      inRAT, outRAT : gdal.RasterAttributeTable
+        The input and output raster attribute tables.
+      outPagedRat : numba.typed.Dict
+        The paged RAT in memory, as created by createPagedRat()
+
     """
     for pageId in outPagedRat:
         ratPage = outPagedRat[pageId]
@@ -1629,7 +1637,7 @@ class RatPage(object):
         numSeg is the number of segments within this page, normally the
         page size, but the last page will be smaller. 
         
-        numIntCols and numFloatCols are as returned by makeFastStatSelection(). 
+        numIntCols and numFloatCols are as returned by makeFastStatsSelection().
         
         """
         self.startSegId = startSegId

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -303,18 +303,12 @@ class TileInfo(object):
 
         Parameters
         ----------
-          xpos : int
-            Pixel column of top left pixel of tile
-          ypos : int
-            Pixel row of top left pixel of tile
-          xsize : int
-            Number of pixel columns in tile
-          ysize : int
-            Number of pixel rows in tile
-          col : int
-            Tile column
-          row : int
-            Tile row
+          xpos, ypos : int
+            Pixel column & row of top left pixel of tile
+          xsize, ysize : int
+            Number of pixel columns & rows in tile
+          col, row : int
+            Tile column & row
 
         """
         self.tiles[(col, row)] = (xpos, ypos, xsize, ysize)
@@ -332,25 +326,20 @@ class TileInfo(object):
         
     def getTile(self, col, row):
         """
-        Return the position and shape of the requested tile
+        Return the position and shape of the requested tile, as
+        a single tuple of values
 
         Parameters
         ----------
-          col : int
-            Tile column
-          row : int
-            Tile row
+          col, row : int
+            Tile column & row
 
         Returns
         -------
-          xpos : int
-            Pixel column of top left pixel of tile
-          ypos : int
-            Pixel row of top left pixel of tile
-          xsize : int
-            Number of pixel columns in tile
-          ysize : int
-            Number of pixel rows in tile
+          xpos, ypos : int
+            Pixel column & row of top left pixel of tile
+          xsize, ysize : int
+            Number of pixel columns & rows in tile
 
         """
 

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -1150,10 +1150,6 @@ def calcHistogramTiled(segfile, maxSegId, writeToRat=True):
       hist : int ndarray (numSegments+1, )
         Histogram counts for each segment (index is segment ID number)
 
-    segfile can be either a filename string, or an open 
-    gdal.Dataset object. If writeToRat is True, then a Dataset
-    object should be opened for update. 
-    
     """
     # This is the histogram array, indexed by segment ID. 
     # Currently just in memory, it could be quite large, 

--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -1099,7 +1099,6 @@ def accumulateSegSpatial(segDict, noDataDict, imgNullVal, tileSegments,
                     segList.append(pt)
 
 
-   
 @njit
 def convertPtsInto2DArray(pts, imgNullVal):
     """

--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -274,6 +274,26 @@ def calcStatsForCompletedSegs(segDict, noDataDict, missingStatsValue, pagedRat,
     Calculate statistics for all complete segments in the segDict.
     Update the pagedRat with the resulting entries. Completed segments
     are then removed from segDict. 
+
+    Parameters
+    ----------
+      segDict : numba.typed.Dict 
+        Dictionary of segments keyed on segment id. Values are histograms for the segment
+      noDataDict : numba.typed.Dict
+        Dictionary of nodata values for each segment.
+      missingStatsValue : int
+        value to insert into the RAT where no valid pixels were found
+      pagedRat : numba.typed.Dict
+        The RAT as a paged data structure
+      statsSelection_fast : int ndarray of shape (numStats, 2)
+        Allows quick access to the types of stats required
+      segSize : numba.typed.Dict
+        Dictionary of the total segment size of each segment
+      numIntCols : int
+        Number of Integer RAT cols to be created
+      numFloatCols : int
+        Number of Float RAT cols to be created
+
     """
     numStats = len(statsSelection_fast)
     maxSegId = len(segSize) - 1
@@ -319,6 +339,12 @@ def createSegDict():
     a single segment. Each of its entries is for a single value from 
     the imagery, the key is the pixel value, and the dictionary value 
     is the number of times that pixel value appears in the segment. 
+
+    Returns
+    -------
+     segDict : numba.typed.Dict 
+       Dictionary of histograms used for calculating statistics.
+
     """
     histDict = Dict.empty(key_type=tiling.numbaTypeForImageType, value_type=types.uint32)
     segDict = Dict.empty(key_type=tiling.segIdNumbaType, value_type=histDict._dict_type)
@@ -330,6 +356,12 @@ def createNoDataDict():
     Create the dictionary that holds counts of nodata seen for each 
     segment. The key is the segId, value is the count of nodata seen 
     for that segment in the image data.
+
+    Returns
+    -------
+     nodataDict : numba.typed.Dict 
+       Dictionary of nodata counts for each segment
+       
     """
     noDataDict = Dict.empty(key_type=tiling.segIdNumbaType, value_type=types.uint32)
     return noDataDict
@@ -339,6 +371,17 @@ def checkHistColumn(existingColNames):
     """
     Check for the Histogram column in the attribute table. Return
     its column number, and raise an exception if it is not present
+
+    Parameters
+    ----------
+      existingColNames : list of strings
+        The existing column names in the segment file
+
+    Returns
+    -------
+      histColNdx : int
+        The index of the histogram column
+
     """
     histColNdx = -1
     for i in range(len(existingColNames)):

--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -1153,6 +1153,7 @@ def accumulateSegSpatial(segDict, noDataDict, imgNullVal, tileSegments,
                     pt = SegPoint(leftPix + x, topLine + y, imgVal_typed)
                     segList.append(pt)
 
+
 @njit
 def checkSegCompleteSpatial(segDict, noDataDict, segSize, segId):
     """
@@ -1192,6 +1193,7 @@ def checkSegCompleteSpatial(segDict, noDataDict, segSize, segId):
         count += noDataDict[segId]
 
     return (count == segSize[segId])
+
 
 @njit
 def convertPtsInto2DArray(pts, imgNullVal):

--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -70,39 +70,35 @@ def calcPerSegmentStatsTiled(imgfile, imgbandnum, segfile,
         in this file.
       statsSelection : list of tuples.
         One tuple for each statistic to be included. Each tuple is either 2
-        or 3 elements:
-        
-        ::
+        or 3 elements::
         
           (columnName, statName)
         
-        or
-        
-        ::
+        or ::
         
           (columnName, statName, parameter)
         
         The columnName is a string, used to name the column in the 
         output RAT. 
         The statName is a string used to identify which statistic 
-        is to be calculated. Available options are:
-        
-        :: 
+        is to be calculated. Available options are::
         
           'min', 'max', 'mean', 'stddev', 'median', 'mode', 'percentile', 'pixcount'
         
         The 'percentile' statistic requires the 3-element form, with 
-        the 3rd element being the percentile to be calculated. 
-        For example:
+        the 3rd element being the percentile to be calculated.
+
+        For example::
         
-        ::
-        
-          [('Band1_Mean', 'mean'),('Band1_stdDev', 'stddev'), 
-          ('Band1_LQ', 'percentile', 25),('Band1_UQ', 'percentile', 75)]
+          [('Band1_Mean', 'mean'),
+           ('Band1_stdDev', 'stddev'),
+           ('Band1_LQ', 'percentile', 25),
+           ('Band1_UQ', 'percentile', 75)]
         
         would create 4 columns, for the per-segment mean and 
         standard deviation of the given band, and the lower and upper 
-        quartiles, with corresponding column names. 
+        quartiles, with corresponding column names.
+
         Any pixels that are set to the nodata value of imgfile (if set)
         are ignored in the stats calculations. If there are no pixels
         that aren't the nodata value then the value passed in as

--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -59,46 +59,49 @@ def calcPerSegmentStatsTiled(imgfile, imgbandnum, segfile,
     very large rasters to be processed. Raster data is handled in 
     small tiles, attribute table is handled in fixed-size chunks. 
     
-    The statsSelection parameter is a list of tuples, one for each
-    statistics to be included. Each tuple is either 2 or 3 elements,
-
-        (columnName, statName) or (columnName, statName, parameter)
-
-    The 3-element form is used for any statistic which requires
-    a parameter, which currently is only the percentile. 
-    
-    The columnName is a string, used to name the column in the 
-    output RAT. 
-    The statName is a string used to identify which statistic 
-    is to be calculated. Available options are:
-
-        'min', 'max', 'mean', 'stddev', 'median', 'mode', 
-        'percentile', 'pixcount'.
-
-    The 'percentile' statistic requires the 3-element form, with 
-    the 3rd element being the percentile to be calculated. 
-    
-    For example::
-
-        [
-         ('Band1_Mean', 'mean'),
-         ('Band1_stdDev', 'stddev'),
-         ('Band1_LQ', 'percentile', 25),
-         ('Band1_UQ', 'percentile', 75)
-        ]
-
-    would create 4 columns, for the per-segment mean and 
-    standard deviation of the given band, and the lower and upper 
-    quartiles, with corresponding column names. 
-    
-    Any pixels that are set to the nodata value of imgfile (if set)
-    are ignored in the stats calculations. If there are no pixels
-    that aren't the nodata value then the value passed in as
-    missingStatsValue is put into the RAT for the requested
-    statistics.
-    
-    The 'pixcount' statName can be used to find the number of
-    valid pixels (not nodata) that were used to calculate the statistics.
+    Parameters
+    ----------
+      imgfile : string
+        Path to input file for collecting statistics from
+      imgbandnum : int
+        1-based index of the band number in imgfile to use for collecting stats
+      segfile : string
+        Path to segmented file. Will collect stats in imgfile for each segment
+        in this file.
+      statsSelection : list of tuples.
+        One tuple for each statistic to be included. Each tuple is either 2
+        or 3 elements:
+        
+        >>> (columnName, statName)
+        
+        or
+        
+        >>> (columnName, statName, parameter)
+        
+        The columnName is a string, used to name the column in the 
+        output RAT. 
+        The statName is a string used to identify which statistic 
+        is to be calculated. Available options are:
+        
+        >>> ['min', 'max', 'mean', 'stddev', 'median', 'mode', 'percentile', 'pixcount']
+        
+        The 'percentile' statistic requires the 3-element form, with 
+        the 3rd element being the percentile to be calculated. 
+        For example::
+        
+        >>> statsSelection = [('Band1_Mean', 'mean'),('Band1_stdDev', 'stddev'),
+        >>> ('Band1_LQ', 'percentile', 25),('Band1_UQ', 'percentile', 75)]
+        
+        would create 4 columns, for the per-segment mean and 
+        standard deviation of the given band, and the lower and upper 
+        quartiles, with corresponding column names. 
+        Any pixels that are set to the nodata value of imgfile (if set)
+        are ignored in the stats calculations. If there are no pixels
+        that aren't the nodata value then the value passed in as
+        missingStatsValue is put into the RAT for the requested
+        statistics.
+        The 'pixcount' statName can be used to find the number of
+        valid pixels (not nodata) that were used to calculate the statistics.
 
     """
     segds = segfile
@@ -179,6 +182,19 @@ def accumulateSegDict(segDict, noDataDict, imgNullVal, tileSegments, tileImageDa
     """
     Accumulate per-segment histogram counts for all
     pixels in the given tile. Updates segDict entries in-place.
+    
+    Parameters
+    ----------
+      segDict : numba.typed.Dict 
+        Dictionary of segments keyed on segment id. Values are histograms for the segment
+      noDataDict : numba.typed.Dict
+        Dictionary of nodata values for each segment.
+      imgNullVal : int
+        No data value for image
+      tileSegments : int ndarray of shape (nRows, nCols)
+        Contains the tile of segments currently being processed.
+      tileImageData : int ndarray of shape (nRows, nCols)
+        Contains the tile of the image data currently being processed.
 
     """
     ysize, xsize = tileSegments.shape
@@ -220,6 +236,22 @@ def checkSegComplete(segDict, noDataDict, segSize, segId):
     in the segDict, meaning that the pixel count is equal to
     the segment size
 
+    Parameters
+    ----------
+      segDict : numba.typed.Dict 
+        Dictionary of segments keyed on segment id. Values are histograms for the segment
+      noDataDict : numba.typed.Dict
+        Dictionary of nodata values for each segment.
+      segSize : numba.typed.Dict
+        Dictionary of the total segment size of each segment
+      segId: int
+        Segment to check for completeness
+
+    Returns
+    -------
+     complete : bool
+       Whether the segId is complete or not
+      
     """
     count = 0
     # add up the counts of the histogram

--- a/pyshepseg/utils.py
+++ b/pyshepseg/utils.py
@@ -75,7 +75,14 @@ def estimateStatsFromHisto(bandObj, hist):
 
 def addOverviews(ds):
     """
-    Mimic rios.calcstats behaviour
+    Add raster overviews to the given file.
+    Mimic rios.calcstats behaviour to decide how many overviews.
+
+    Parameters
+    ----------
+      ds : gdal.Dataset
+        Open Dataset for the raster file
+
     """
     # first we work out how many overviews to build based on the size
     if ds.RasterXSize < ds.RasterYSize:
@@ -94,9 +101,16 @@ def addOverviews(ds):
 def writeRandomColourTable(outBand, nRows):
     """
     Attach a randomly-generated colour table to the given segmentation
-    image. The image is given as an open gdal.Band object. Also
-    requires the number of rows in the attribute table, i.e. the
-    number of segments + 1. 
+    image. Mainly useful so the segmentation boundaries can be viewed,
+    without any regard to the meaning of the segments.
+
+    Parameters
+    ----------
+      outBand : gdal.Band
+        Open GDAL Band object for the segmentation image
+      nRows : int
+        Number of rows in the attribute table, equal to the
+        number of segments + 1.
     
     """
     nRows = int(nRows)
@@ -131,15 +145,22 @@ def writeColorTableFromRatColumns(segfile, redColName, greenColName,
     the segmented image will display similarly to same bands of the 
     the original image. 
 
-    segfile is the completed segmentation image, with RAT columns 
-    already written. 
-
-    The three column names are strings, being the names of columns 
-    to use to derive corresponding colors. 
-
     The general idea is that the given columns would be the per-segment 
-    means of the desired bands (see tiling.calcPerSegmentStatsTiled()
+    mean values of the desired bands (see tiling.calcPerSegmentStatsTiled()
     to create such columns). 
+
+    Parameters
+    ----------
+      segfile : str
+        Filename of the completed segmentation image, with RAT columns
+        already written.
+      redColName : str
+        Name of the column in the RAT to use for the red color
+      greenColName : str
+        Name of the column in the RAT to use for the green color
+      blueColName : str
+        Name of the column in the RAT to use for the blue color
+
     """
     colList = [redColName, greenColName, blueColName]
     colorColList = ['Red', 'Green', 'Blue']


### PR DESCRIPTION
Switch on numpydoc Sphinx extension, and have a go at re-formatting the shepseg module, to see how it might look. This is very much just to test and see. Initially only modified the shepseg module. It took a couple of hours, I think, but not too bad. 

Ping @gillins 
No rush. When you get a moment, have a look at the rendered RTD page, and at the original code, and see what you think. 

I think it is do-able, if we want to. It certainly does lots of nice formatting without the really dense docstrings that raw Sphinx requires, but it does still require some discipline. I have left some of the docstrings raw, because some are nice and short as they are, without needing much formatting. Or we could get really rigid and make everything conform to the same pattern. I dunno.....

I used the References facility in the main module docstring, which seems nice, but also perhaps overly complicated. 

The See Also section automatically makes links out of things, which is cool, but also more complicated. 

No urgency at all, just playing because I can. :-)

