### PR TITLE
Numpydoc and jitclass

### DIFF
--- a/pyshepseg/guardeddecorators.py
+++ b/pyshepseg/guardeddecorators.py
@@ -1,0 +1,43 @@
+"""
+A dreadful hack to get around the fact that the numpydoc Sphinx extension
+does not play well with numba's jitclass decorator.
+
+If we are running with Sphinx, then fake the jitclass decorator so that it
+just returns the class it is decorating. 
+
+"""
+import sys
+
+if 'sphinx' not in sys.modules:
+    from numba.experimental import jitclass
+else:
+    def jitclass(cls_or_spec=None, spec=None):
+        """
+        Our fake jitclass decorator. Hacked from the real one
+        in numba. 
+
+        Returns
+        -------
+        If used as a decorator, returns a callable that takes a class
+        object and returns the same class. In short, this decorator does
+        nothing at all.
+
+        """
+
+        if (cls_or_spec is not None and
+            spec is None and
+                not isinstance(cls_or_spec, type)):
+            # Used like
+            # @jitclass([("x", intp)])
+            # class Foo:
+            #     ...
+            spec = cls_or_spec
+            cls_or_spec = None
+
+        def wrap(cls):
+            return cls
+
+        if cls_or_spec is None:
+            return wrap
+        else:
+            return wrap(cls_or_spec)

--- a/pyshepseg/guardeddecorators.py
+++ b/pyshepseg/guardeddecorators.py
@@ -3,7 +3,7 @@ A dreadful hack to get around the fact that the numpydoc Sphinx extension
 does not play well with numba's jitclass decorator.
 
 If we are running with Sphinx, then fake the jitclass decorator so that it
-just returns the class it is decorating. 
+just returns the class it is decorating.
 
 """
 import sys
@@ -14,7 +14,7 @@ else:
     def jitclass(cls_or_spec=None, spec=None):
         """
         Our fake jitclass decorator. Hacked from the real one
-        in numba. 
+        in numba.
 
         Returns
         -------

--- a/pyshepseg/shepseg.py
+++ b/pyshepseg/shepseg.py
@@ -83,12 +83,13 @@ References
 # Just in case anyone is trying to use this with Python-2
 from __future__ import print_function, division
 
+import sys
 import time
 
 import numpy
 from sklearn.cluster import KMeans
 from numba import njit
-from numba.experimental import jitclass
+from .guardeddecorators import jitclass
 from numba.core import types
 from numba.typed import Dict
 
@@ -869,7 +870,11 @@ class RowColArray(object):
         return (self.rowcols[:, 0], self.rowcols[:, 1])
 
 
-RowColArray_Type = RowColArray.class_type.instance_type
+if 'sphinx' not in sys.modules:
+    RowColArray_Type = RowColArray.class_type.instance_type
+else:
+    # We are running in a Sphinx documentation build, so fake this
+    RowColArray_Type = None
 
 
 @njit

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -70,7 +70,7 @@ import scipy.stats
 from numba import njit
 from numba.core import types
 from numba.typed import Dict
-from numba.experimental import jitclass
+from .guardeddecorators import jitclass
 
 from . import shepseg
 

--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -41,7 +41,7 @@ from osgeo import osr
 from numba import njit, typeof
 from numba.core import types
 from numba.typed import Dict, List
-from numba.experimental import jitclass
+from .guardeddecorators import jitclass
 
 from . import tiling
 from . import shepseg


### PR DESCRIPTION
This kludge will allow classes decorated with `@jitclass` to also render in Sphinx with the numpydoc extension. These two don't play well together, so this fakes the jitclass decorator when running with sphinx. 

The last bit of ugliness I had to do was in shepseg.py, where I needed to make the `RowColArray_Type` declaration conditional on no sphinx. I tried several ways around this, but they either failed with sphinx, or failed when running for real, so this is all I have left. 

One thing I had hopes for was making the fake jitclass decorator return a derived class with an extra field for .class_type.instance_type. This works, in principle, but numpydoc won't render the resulting class, whereas if it returns the real original class, numpydoc renders it fine. I don't understand why. 

@gillins Any thoughts?
