### PR TITLE
Create array of page ID keys, to avoid NumbaTypeSafetyWarning

### DIFF
--- a/pyshepseg/subset.py
+++ b/pyshepseg/subset.py
@@ -433,7 +433,14 @@ def writeCompletedPagesForSubset(inRAT, outRAT, outPagedRat):
         The paged RAT in memory, as created by createPagedRat()
 
     """
+    # Make an array of the pageId values, with the correct type (SegIdType)
+    pagedRatKeys = numpy.empty(len(outPagedRat), dtype=shepseg.SegIdType)
+    i = 0
     for pageId in outPagedRat:
+        pagedRatKeys[i] = pageId
+        i += 1
+
+    for pageId in pagedRatKeys:
         ratPage = outPagedRat[pageId]
         if ratPage.pageComplete():
             # this one one is complete. Grow RAT if required

--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -454,7 +454,8 @@ def writeCompletePages(pagedRat, attrTbl, statsSelection_fast):
  
     """
     numStat = len(statsSelection_fast)
-    
+
+    # Make an array of the pageId values, with the correct type (SegIdType)
     pagedRatKeys = numpy.empty(len(pagedRat), dtype=shepseg.SegIdType)
     i = 0
     for pageId in pagedRat:


### PR DESCRIPTION
I had exactly the same problem in tilingstats.writeCompletePages(), and have copied the same solution to subset.writeCompletedPagesForSubset(). 

The for loop should get the type right by itself, but it just gives int. I suspect that there is a deficiency in the way numa.typed.Dict makes it iterator, but that is for another day. (Note to self - look into this.....)

Anyway, this gets rid of the warning message. 