### PR TITLE
cope with new version of scipy and changed behaviour of stats.mode

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+    
 python:
   install:
     - requirements: doc/requirements.txt

--- a/pyshepseg/tiling.py
+++ b/pyshepseg/tiling.py
@@ -1002,7 +1002,12 @@ def recodeSharedSegments(tileData, overlapA, overlapB, orientation,
         # pixels from the B overlap array. In principle there 
         # should only be one, but just in case. 
         modeObj = scipy.stats.mode(overlapB[segNdx])
-        segIdFromB = modeObj.mode[0]
+        # change in scipy 1.9.0. use keepdims=True for old behaviour
+        # but that breaks older scipy. So workaround by seeing what returned
+        if numpy.isscalar(modeObj.mode):
+            segIdFromB = modeObj.mode
+        else:
+            segIdFromB = modeObj.mode[0]
         
         # Now record this recoding relationship
         recodeDict[segid] = segIdFromB


### PR DESCRIPTION
As spotted by @t-hackwood `pyshepseg` fails to do tiled segmentation with a recent scipy as it tries to index a scalar. The problem is that the behaviour changed in [scipy 1.9.0 ](https://docs.scipy.org/doc/scipy/release/1.9.0-notes.html) where a `keepdims` parameter was added to the stats functions. Now returns a scalar for 1d inputs by default. 

`keepdims=True` will revert to the previous behaviour (return a 1d array for 1d inputs), but since this wasn't an option on earlier scipy, this will break older installs. 

So my approach was to do a test on what is returned. Tested on scipy 1.8 and 1.12.

Any thoughts @neilflood (no hurry on this) ?