### PR TITLE
Add spatial stats step to AWS Batch

### DIFF
--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -128,6 +128,7 @@ def main():
     # this one only runs when the array jobs are all done
     cmd = ['/usr/bin/python3', '/ubarscsw/bin/do_stitch.py',
         '--bucket', cmdargs.bucket, '--outfile', cmdargs.outfile,
+        '--tileprefix', cmdargs.tileprefix,
         '--infile', cmdargs.infile, '--pickle', cmdargs.pickle,
         '--overlapsize', str(cmdargs.overlapsize)]
     if cmdargs.stats is not None:

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -34,6 +34,8 @@ def getCmdargs():
         help="Tile Size to use.")
     p.add_argument("--overlapsize", required=True, type=int,
         help="Tile Overlap to use.")
+    p.add_argument("--tileprefix", default='tile',
+        help="Unique prefix to save the output tiles with. (default=%(default)s)")
     p.add_argument("--pickle", required=True,
         help="name of pickle to save result of preparation into")
     p.add_argument("--region", default="us-west-2",
@@ -45,10 +47,15 @@ def getCmdargs():
     p.add_argument("--jobdefnstitch", default="PyShepSegBatchJobDefinitionStitch",
         help="Name of Job Definition to use for the stitch job. (default=%(default)s)")
     p.add_argument("--stats", help="path to json file specifying stats in format:" +
-        "bucket:path/in/bucket.json")
+        "bucket:path/in/bucket.json. Contents must be a list of [img, band, " +
+        "statsSelection] tuples.")
+    p.add_argument("--spatialstats", help="path to json file specifying spatial " +
+        "stats in format: bucket:path/in/bucket.jso. Contents must be a list of " +
+        "[img, band, [list of (colName, colType) tuples], name-of-userfunc, param]" +
+        " tuples.")
     p.add_argument("--nogdalstats", action="store_true", default=False,
         help="don't calculate GDAL's statistics or write a colour table. " + 
-            "Can't be used with --stats.")
+            "Can't be used with --stats or --spatialstats.")
     p.add_argument("--minSegmentSize", type=int, default=50, required=False,
         help="Segment size for segmentation (default=%(default)s)")
     p.add_argument("--numClusters", type=int, default=60, required=False,
@@ -105,7 +112,7 @@ def main():
     containerOverrides = {
         "command": ['/usr/bin/python3', '/ubarscsw/bin/do_tile.py',
         '--bucket', cmdargs.bucket, '--pickle', cmdargs.pickle,
-        '--infile', cmdargs.infile, 
+        '--infile', cmdargs.infile, '--tileprefix', cmdargs.tileprefix,
         '--minSegmentSize', str(cmdargs.minSegmentSize),
         '--maxSpectDiff', cmdargs.maxSpectDiff, 
         '--spectDistPcntile', str(cmdargs.spectDistPcntile)]}
@@ -125,6 +132,8 @@ def main():
         '--overlapsize', str(cmdargs.overlapsize)]
     if cmdargs.stats is not None:
         cmd.extend(['--stats', cmdargs.stats])
+    if cmdargs.spatialstats is not None:
+        cmd.extend(['--spatialstats', cmdargs.spatialstats])
     if cmdargs.nogdalstats:
         cmd.append('--nogdalstats')
 

--- a/parallel_examples/awsbatch/do_tile.py
+++ b/parallel_examples/awsbatch/do_tile.py
@@ -38,6 +38,8 @@ def getCmdargs():
         help="S3 Bucket to use")
     p.add_argument("--infile", required=True,
         help="Path in --bucket to use as input file")
+    p.add_argument("--tileprefix", required=True,
+        help="Unique prefix to save the output tiles with.")
     p.add_argument("--pickle", required=True,
         help="name of pickle with the result of the preparation")
     p.add_argument("--minSegmentSize", type=int, default=50, required=False,
@@ -80,7 +82,8 @@ def main():
     # - they must match. Potentially a database or similar
     # could have been used to notify of the names of tiles 
     # but this would add more complexity.
-    filename = 'tile_{}_{}.{}'.format(col, row, 'tif')
+    filename = '{}_{}_{}.{}'.format(cmdargs.tileprefix, 
+        col, row, 'tif')
     filename = os.path.join(tempDir, filename)
 
     # test if int

--- a/parallel_examples/awsbatch/submit-pyshepseg-job.py
+++ b/parallel_examples/awsbatch/submit-pyshepseg-job.py
@@ -26,6 +26,8 @@ def getCmdargs():
         help="Path in --bucket to use as input file")
     p.add_argument("--outfile", required=True,
         help="Path in --bucket to use as output file (.kea)")
+    p.add_argument("--tileprefix",
+        help="Unique prefix to save the output tiles with.")
     p.add_argument("-b", "--bands",
         help="Comma seperated list of bands to use. 1-based. Uses all bands by default.")
     p.add_argument("--jobqueue", default="PyShepSegBatchProcessingJobQueue",
@@ -45,9 +47,13 @@ def getCmdargs():
     p.add_argument("--stats", help="path to json file specifying stats in format:" +
         "bucket:path/in/bucket.json. Contents must be a list of [img, band, " +
         "statsSelection] tuples.")
+    p.add_argument("--spatialstats", help="path to json file specifying spatial " +
+        "stats in format: bucket:path/in/bucket.jso. Contents must be a list of " +
+        "[img, band, [list of (colName, colType) tuples], name-of-userfunc, param]" +
+        " tuples.")
     p.add_argument("--nogdalstats", action="store_true", default=False,
         help="don't calculate GDAL's statistics or write a colour table. " + 
-            "Can't be used with --stats.")
+            "Can't be used with --stats or --spatialstats.")
     p.add_argument("--minSegmentSize", type=int, default=50, required=False,
         help="Segment size for segmentation (default=%(default)s)")
     p.add_argument("--numClusters", type=int, default=60, required=False,
@@ -84,8 +90,12 @@ def main():
         cmd.extend(['--bands', cmdargs.bands])
     if cmdargs.stats is not None:
         cmd.extend(['--stats', cmdargs.stats])
+    if cmdargs.spatialstats is not None:
+        cmd.extend(['--spatialstats', cmdargs.spatialstats])
     if cmdargs.nogdalstats:
         cmd.append('--nogdalstats')
+    if cmdargs.tileprefix is not None:
+        cmd.extend(['--tileprefix', cmdargs.tileprefix])
 
     # submit the prepare job
     response = batch.submit_job(jobName="pyshepseg_prepare",


### PR DESCRIPTION
Also add `--tileprefix` so multiple jobs can run at once without clobbering each other's files.

And delete tiles ASAP to release space.