### PR TITLE
Add --noremove option to tiling jobs. Pull out alignment code check into a separate function

### DIFF
--- a/parallel_examples/awsbatch/Dockerfile
+++ b/parallel_examples/awsbatch/Dockerfile
@@ -41,9 +41,9 @@ RUN cd /tmp \
 ENV RIOS_VERSION=2.0.3
 RUN cd /tmp \
     && wget -q https://github.com/ubarsc/rios/releases/download/rios-${RIOS_VERSION}/rios-${RIOS_VERSION}.tar.gz \
-    && tar xf rios-${RIOS_VERSION} \
+    && tar xf rios-${RIOS_VERSION}.tar.gz \
     && cd rios-${RIOS_VERSION} \
-    && pip install . \
+    && DEB_PYTHON_INSTALL_LAYOUT=deb_system pip install . \
     && cd .. \
     && rm -rf rios-${RIOS_VERSION} rios-${RIOS_VERSION}.tar.gz
 

--- a/parallel_examples/awsbatch/Dockerfile
+++ b/parallel_examples/awsbatch/Dockerfile
@@ -37,18 +37,9 @@ RUN cd /tmp \
     && make install \
     && cd ../.. \
     && rm -rf kealib-${KEALIB_VERSION} kealib-${KEALIB_VERSION}.tar.gz
-    
-ENV RIOS_VERSION=2.0.3
-RUN cd /tmp \
-    && wget -q https://github.com/ubarsc/rios/releases/download/rios-${RIOS_VERSION}/rios-${RIOS_VERSION}.tar.gz \
-    && tar xf rios-${RIOS_VERSION}.tar.gz \
-    && cd rios-${RIOS_VERSION} \
-    && DEB_PYTHON_INSTALL_LAYOUT=deb_system pip install . \
-    && cd .. \
-    && rm -rf rios-${RIOS_VERSION} rios-${RIOS_VERSION}.tar.gz
 
 COPY pyshepseg-$PYSHEPSEG_VER.tar.gz /tmp
-# install pyshegseg
+# install RIOS
 RUN cd /tmp && tar xf pyshepseg-$PYSHEPSEG_VER.tar.gz \
     && cd pyshepseg-$PYSHEPSEG_VER \
     && DEB_PYTHON_INSTALL_LAYOUT=deb_system pip install . \
@@ -82,9 +73,9 @@ RUN apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER $SERVICEUSER
 
 # a few quick tests
+#RUN gdal_translate --formats | grep KEA
 RUN python3 -c 'from osgeo import gdal;assert(gdal.GetDriverByName("KEA") is not None)'
 RUN python3 -c 'from pyshepseg import tiling'
-RUN python3 -c 'from rios import applier'
 
 # export the volume
 VOLUME $SW_VOLUME

--- a/parallel_examples/awsbatch/Dockerfile
+++ b/parallel_examples/awsbatch/Dockerfile
@@ -37,9 +37,18 @@ RUN cd /tmp \
     && make install \
     && cd ../.. \
     && rm -rf kealib-${KEALIB_VERSION} kealib-${KEALIB_VERSION}.tar.gz
+    
+ENV RIOS_VERSION=2.0.3
+RUN cd /tmp \
+    && wget -q https://github.com/ubarsc/rios/releases/download/rios-${RIOS_VERSION}/rios-${RIOS_VERSION}.tar.gz \
+    && tar xf rios-${RIOS_VERSION} \
+    && cd rios-${RIOS_VERSION} \
+    && pip install . \
+    && cd .. \
+    && rm -rf rios-${RIOS_VERSION} rios-${RIOS_VERSION}.tar.gz
 
 COPY pyshepseg-$PYSHEPSEG_VER.tar.gz /tmp
-# install RIOS
+# install pyshegseg
 RUN cd /tmp && tar xf pyshepseg-$PYSHEPSEG_VER.tar.gz \
     && cd pyshepseg-$PYSHEPSEG_VER \
     && DEB_PYTHON_INSTALL_LAYOUT=deb_system pip install . \
@@ -73,9 +82,9 @@ RUN apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER $SERVICEUSER
 
 # a few quick tests
-#RUN gdal_translate --formats | grep KEA
 RUN python3 -c 'from osgeo import gdal;assert(gdal.GetDriverByName("KEA") is not None)'
 RUN python3 -c 'from pyshepseg import tiling'
+RUN python3 -c 'from rios import applier'
 
 # export the volume
 VOLUME $SW_VOLUME

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -64,6 +64,8 @@ def getCmdargs():
         help="Maximum spectral difference for segmentation (default=%(default)s)")
     p.add_argument("--spectDistPcntile", type=int, default=50, required=False,
         help="Spectral Distance Percentile for segmentation (default=%(default)s)")
+    p.add_argument("--noremove", action="store_true", default=False,
+        help="don't remove files from S3 (for debugging)")
 
     cmdargs = p.parse_args()
     if cmdargs.bands is not None:
@@ -137,6 +139,8 @@ def main():
         cmd.extend(['--spatialstats', cmdargs.spatialstats])
     if cmdargs.nogdalstats:
         cmd.append('--nogdalstats')
+    if cmdargs.noremove:
+        cmd.append('--noremove')
 
     response = batch.submit_job(jobName="pyshepseg_stitch",
         jobQueue=cmdargs.jobqueue,

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -111,11 +111,6 @@ def main():
 
     # now submit an array job with all the tiles
     # (can't do this before now because we don't know how many tiles)
-    arrayProperties = {}
-    if len(colRowList) > 1:
-        # throws error if this is 1...
-        arrayProperties = {'size': len(colRowList)}
-    
     containerOverrides = {
         "command": ['/usr/bin/python3', '/ubarscsw/bin/do_tile.py',
         '--bucket', cmdargs.bucket, '--pickle', cmdargs.pickle,
@@ -123,6 +118,16 @@ def main():
         '--minSegmentSize', str(cmdargs.minSegmentSize),
         '--maxSpectDiff', cmdargs.maxSpectDiff, 
         '--spectDistPcntile', str(cmdargs.spectDistPcntile)]}
+
+    arrayProperties = {}
+    if len(colRowList) > 1:
+        # throws error if this is 1...
+        arrayProperties = {'size': len(colRowList)}
+    else:
+        # must fake AWS_BATCH_JOB_ARRAY_INDEX
+        containerOverrides['environment'] = {'name': 'AWS_BATCH_JOB_ARRAY_INDEX',
+            'value': '0'}
+
     response = batch.submit_job(jobName="pyshepseg_tiles",
         jobQueue=cmdargs.jobqueue,
         jobDefinition=cmdargs.jobdefntile,

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -122,7 +122,7 @@ def main():
     arrayProperties = {}
     if len(colRowList) > 1:
         # throws error if this is 1...
-        arrayProperties['size'] = len(colRowList)}
+        arrayProperties['size'] = len(colRowList)
     else:
         # must fake AWS_BATCH_JOB_ARRAY_INDEX
         containerOverrides['environment'] = {'name': 'AWS_BATCH_JOB_ARRAY_INDEX',

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -111,6 +111,11 @@ def main():
 
     # now submit an array job with all the tiles
     # (can't do this before now because we don't know how many tiles)
+    arrayProperties = None
+    if len(colRowList) > 1:
+        # throws error if this is 1...
+        arrayProperties = {'size': len(colRowList)}
+    
     containerOverrides = {
         "command": ['/usr/bin/python3', '/ubarscsw/bin/do_tile.py',
         '--bucket', cmdargs.bucket, '--pickle', cmdargs.pickle,
@@ -121,7 +126,7 @@ def main():
     response = batch.submit_job(jobName="pyshepseg_tiles",
         jobQueue=cmdargs.jobqueue,
         jobDefinition=cmdargs.jobdefntile,
-        arrayProperties={'size': len(colRowList)},
+        arrayProperties=arrayProperties,
         containerOverrides=containerOverrides)
     tilesJobId = response['jobId']
     print('Tiles Job Id', tilesJobId)

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -125,8 +125,8 @@ def main():
         arrayProperties['size'] = len(colRowList)
     else:
         # must fake AWS_BATCH_JOB_ARRAY_INDEX
-        containerOverrides['environment'] = {'name': 'AWS_BATCH_JOB_ARRAY_INDEX',
-            'value': '0'}
+        containerOverrides['environment'] = [{'name': 'AWS_BATCH_JOB_ARRAY_INDEX',
+            'value': '0'}]
 
     response = batch.submit_job(jobName="pyshepseg_tiles",
         jobQueue=cmdargs.jobqueue,

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -122,7 +122,7 @@ def main():
     arrayProperties = {}
     if len(colRowList) > 1:
         # throws error if this is 1...
-        arrayProperties = {'size': len(colRowList)}
+        arrayProperties['size'] = len(colRowList)}
     else:
         # must fake AWS_BATCH_JOB_ARRAY_INDEX
         containerOverrides['environment'] = {'name': 'AWS_BATCH_JOB_ARRAY_INDEX',

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -111,7 +111,7 @@ def main():
 
     # now submit an array job with all the tiles
     # (can't do this before now because we don't know how many tiles)
-    arrayProperties = None
+    arrayProperties = {}
     if len(colRowList) > 1:
         # throws error if this is 1...
         arrayProperties = {'size': len(colRowList)}

--- a/parallel_examples/awsbatch/do_prepare.py
+++ b/parallel_examples/awsbatch/do_prepare.py
@@ -125,8 +125,8 @@ def main():
         arrayProperties['size'] = len(colRowList)
     else:
         # must fake AWS_BATCH_JOB_ARRAY_INDEX
-        containerOverrides['environment'] = [{'name': 'AWS_BATCH_JOB_ARRAY_INDEX',
-            'value': '0'}]
+        # can't set this as and env var as Batch overrides
+        containerOverrides['command'].extend(['--arrayindex', '0'])
 
     response = batch.submit_job(jobName="pyshepseg_tiles",
         jobQueue=cmdargs.jobqueue,

--- a/parallel_examples/awsbatch/do_stitch.py
+++ b/parallel_examples/awsbatch/do_stitch.py
@@ -49,6 +49,8 @@ def getCmdargs():
     p.add_argument("--nogdalstats", action="store_true", default=False,
         help="don't calculate GDAL's statistics or write a colour table. " + 
             "Can't be used with --stats.")
+    p.add_argument("--noremove", action="store_true", default=False,
+        help="don't remove files from S3 (for debugging)")
 
     cmdargs = p.parse_args()
 
@@ -93,15 +95,16 @@ def main():
         cmdargs.overlapsize, tempDir)
 
     # clean up files to release space
-    objs = []
-    for col, row in tileFilenames:
-        filename = '{}_{}_{}.{}'.format(cmdargs.tileprefix, col, row, 'tif')
-        objs.append({'Key': filename})
-
-    # workaround 1000 at a time limit
-    while len(objs) > 0:
-        s3.delete_objects(Bucket=cmdargs.bucket, Delete={'Objects': objs[0:1000]})
-        del objs[0:1000]
+    if not cmdargs.noremove:
+        objs = []
+        for col, row in tileFilenames:
+            filename = '{}_{}_{}.{}'.format(cmdargs.tileprefix, col, row, 'tif')
+            objs.append({'Key': filename})
+    
+        # workaround 1000 at a time limit
+        while len(objs) > 0:
+            s3.delete_objects(Bucket=cmdargs.bucket, Delete={'Objects': objs[0:1000]})
+            del objs[0:1000]
 
     # open for the creation of stats
     localDs = gdal.Open(localOutfile, gdal.GA_Update)
@@ -153,13 +156,14 @@ def main():
     s3.upload_file(localOutfile, cmdargs.bucket, cmdargs.outfile)
 
     # cleanup temp files from S3
-    objs = [{'Key': cmdargs.pickle}]
-    if cmdargs.stats is not None:
-        objs.append({'Key': statsKey})
-    if cmdargs.spatialstats is not None:
-        objs.append({'Key': spatialstatsKey})
-
-    s3.delete_objects(Bucket=cmdargs.bucket, Delete={'Objects': objs})
+    if not cmdargs.noremove:
+        objs = [{'Key': cmdargs.pickle}]
+        if cmdargs.stats is not None:
+            objs.append({'Key': statsKey})
+        if cmdargs.spatialstats is not None:
+            objs.append({'Key': spatialstatsKey})
+    
+        s3.delete_objects(Bucket=cmdargs.bucket, Delete={'Objects': objs})
 
     # cleanup
     shutil.rmtree(tempDir)

--- a/parallel_examples/awsbatch/submit-pyshepseg-job.py
+++ b/parallel_examples/awsbatch/submit-pyshepseg-job.py
@@ -59,6 +59,8 @@ def getCmdargs():
         help="Maximum spectral difference for segmentation (default=%(default)s)")
     p.add_argument("--spectDistPcntile", type=int, default=50, required=False,
         help="Spectral Distance Percentile for segmentation (default=%(default)s)")
+    p.add_argument("--noremove", action="store_true", default=False,
+        help="don't remove files from S3 (for debugging)")
 
     cmdargs = p.parse_args()
 
@@ -98,6 +100,8 @@ def main():
         cmd.append('--nogdalstats')
     if cmdargs.tileprefix is not None:
         cmd.extend(['--tileprefix', cmdargs.tileprefix])
+    if cmdargs.noremove:
+        cmd.append('--noremove')
 
     # submit the prepare job
     response = batch.submit_job(jobName="pyshepseg_prepare",


### PR DESCRIPTION
`--noremove` will allow us to check the temporary files and would be useful for debugging.