### PR TITLE
fix broken link

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -42,7 +42,7 @@ Installation
 ------------
 
 This package can be installed from conda-forge and is the recommended approach. 
-Once you have installed `Conda <conda.pydata.org/miniconda.html#miniconda>`_ run 
+Once you have installed `Conda <https://github.com/conda-forge/miniforge>`_ run 
 the following commands to install ``pyshepseg`` into a new environment:
 
 ::


### PR DESCRIPTION
Was a) broken so it rendered like and internal link, and b) pointed to miniconda which we try to discourage (nasty license surprises) and instead use miniforge.