### PR TITLE
Update .readthedocs.yaml for explicit conf.py

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,10 @@ build:
   tools:
     python: "3.12"
     
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+
 python:
   install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
As per [this ReadTheDocs post ](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/), we now have to explicitly identify the Sphinx conf.py
