### PR TITLE
Don't open segmentation file in update mode if it doesn't need to be updated

### DIFF
--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -271,8 +271,9 @@ def calcPerSegmentStatsRIOS(imgfile, imgbandnum, segfile,
     if not HAVE_RIOS:
         raise PyShepSegStatsError('RIOS needs to be installed for this function')
     
+    update = outFile is None
     segds, segband, imgds, imgband = doImageAlignmentChecks(segfile, 
-        imgfile, imgbandnum)
+        imgfile, imgbandnum, update=update)
     
     attrTbl = segband.GetDefaultRAT()
     existingColNames = [attrTbl.GetNameOfCol(i) 

--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -271,9 +271,8 @@ def calcPerSegmentStatsRIOS(imgfile, imgbandnum, segfile,
     if not HAVE_RIOS:
         raise PyShepSegStatsError('RIOS needs to be installed for this function')
     
-    update = outFile is None
     segds, segband, imgds, imgband = doImageAlignmentChecks(segfile, 
-        imgfile, imgbandnum, update=update)
+        imgfile, imgbandnum, update=False)
     
     attrTbl = segband.GetDefaultRAT()
     existingColNames = [attrTbl.GetNameOfCol(i) 
@@ -1422,9 +1421,8 @@ def calcPerSegmentSpatialStatsRIOS(imgfile, imgbandnum, segfile,
     if not HAVE_RIOS:
         raise PyShepSegStatsError('RIOS needs to be installed for this function')
     
-    update = outFile is None
     segds, segband, imgds, imgband = doImageAlignmentChecks(segfile, 
-        imgfile, imgbandnum, update=update)
+        imgfile, imgbandnum, update=False)
 
     attrTbl = segband.GetDefaultRAT()
     existingColNames = [attrTbl.GetNameOfCol(i) 

--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -366,7 +366,7 @@ def calcPerSegmentStatsRIOS(imgfile, imgbandnum, segfile,
         ratapplier.copyRAT(tempKEA, segfile)
 
 
-def doImageAlignmentChecks(segfile, imgfile, imgbandnum):
+def doImageAlignmentChecks(segfile, imgfile, imgbandnum, update=True):
     """
     Do the checks that the segment file and image file that is being used to 
     collect the stats actually align. We refuse to process the files if they
@@ -381,6 +381,8 @@ def doImageAlignmentChecks(segfile, imgfile, imgbandnum):
         Path to input file for collecting statistics from
       imgbandnum : int
         1-based index of the band number in imgfile to use for collecting stats
+      update : bool
+        Whether to open the segfile in update mode or not
 
     Returns
     -------
@@ -395,7 +397,10 @@ def doImageAlignmentChecks(segfile, imgfile, imgbandnum):
     """
     segds = segfile
     if not isinstance(segds, gdal.Dataset):
-        segds = gdal.Open(segfile, gdal.GA_Update)
+        mode = gdal.GA_ReadOnly
+        if update:
+            mode = gdal.GA_Update
+        segds = gdal.Open(segfile, mode)
     segband = segds.GetRasterBand(1)
 
     imgds = imgfile
@@ -1416,8 +1421,9 @@ def calcPerSegmentSpatialStatsRIOS(imgfile, imgbandnum, segfile,
     if not HAVE_RIOS:
         raise PyShepSegStatsError('RIOS needs to be installed for this function')
     
+    update = outFile is None
     segds, segband, imgds, imgband = doImageAlignmentChecks(segfile, 
-        imgfile, imgbandnum)
+        imgfile, imgbandnum, update=update)
 
     attrTbl = segband.GetDefaultRAT()
     existingColNames = [attrTbl.GetNameOfCol(i) 


### PR DESCRIPTION
In this case it is likely to be a `/vsis3` filesystem which cannot be opened in update mode. If the user instead passes in an open dataset as a workaround, then it never gets closed before RIOS runs and seems to cause a HDF5 locking issue.