### PR TITLE
Set temporary file to thematic

### DIFF
--- a/pyshepseg/tilingstats.py
+++ b/pyshepseg/tilingstats.py
@@ -314,6 +314,7 @@ def calcPerSegmentStatsRIOS(imgfile, imgbandnum, segfile,
     keaDriver = gdal.GetDriverByName('KEA')
     tempKEADS = keaDriver.Create(tempKEA, 10, 10, 1, gdal.GDT_UInt32)
     tempKEABand = tempKEADS.GetRasterBand(1)
+    tempKEABand.SetMetadataItem('LAYER_TYPE', 'thematic')
     tempKEAAttrTbl = tempKEABand.GetDefaultRAT()
     # make same size as original
     tempKEAAttrTbl.SetRowCount(segSize.size)
@@ -1474,6 +1475,7 @@ def calcPerSegmentSpatialStatsRIOS(imgfile, imgbandnum, segfile,
     keaDriver = gdal.GetDriverByName('KEA')
     tempKEADS = keaDriver.Create(tempKEA, 10, 10, 1, gdal.GDT_UInt32)
     tempKEABand = tempKEADS.GetRasterBand(1)
+    tempKEABand.SetMetadataItem('LAYER_TYPE', 'thematic')
     tempKEAAttrTbl = tempKEABand.GetDefaultRAT()
     # make same size as original
     tempKEAAttrTbl.SetRowCount(segSize.size)


### PR DESCRIPTION
Minor annoyance, but gdalinfo/tuiview won't show the RAT on these temp files as they aren't set to thematic. It all works ok because KEA allows you to set a RAT on an athematic image but this guards against future KEA changes.